### PR TITLE
Test when caches omit particular headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Possible members of a request object:
                               headers to check the request for on the server.
 - `expected_response_headers` - An array of `[header_name_string, header_value_string]` representing
                               headers to check the response for on the client. See also response_headers.
+- `expected_response_headers_missing` - An array of `header_name_string` representing headers to
+                                      check that the response on the client does not include.
 - `expected_response_text` - A string to check the response body against on the client.
 - `setup` - Boolean to indicate whether this is a setup request; failures don't mean the actual test failed.
 - `setup_tests` - Array of values that indicate whether the specified check is part of setup;

--- a/client.mjs
+++ b/client.mjs
@@ -226,9 +226,9 @@ function makeCheckResponse (idx, config, dump) {
         }
       })
     }
-    if ('expected_response_nonheaders' in config) {
-      config.expected_response_nonheaders.forEach(function (header) {
-        var respSetup = setupCheck(config, 'expected_response_nonheaders')
+    if ('expected_response_headers_missing' in config) {
+      config.expected_response_headers_missing.forEach(function (header) {
+        var respSetup = setupCheck(config, 'expected_response_headers_missing')
         assert(respSetup, !response.headers.has(header),
           `Response ${reqNum} includes unexpected header ${header}: "${response.headers.get(header)}"`)
       })

--- a/client.mjs
+++ b/client.mjs
@@ -226,6 +226,13 @@ function makeCheckResponse (idx, config, dump) {
         }
       })
     }
+    if ('expected_response_nonheaders' in config) {
+      config.expected_response_nonheaders.forEach(function (header) {
+        var respSetup = setupCheck(config, 'expected_response_nonheaders')
+        assert(respSetup, !response.headers.has(header),
+          `Response ${reqNum} includes unexpected header ${header}: "${response.headers.get(header)}"`)
+      })
+    }
     return response.text()
   }
 }

--- a/tests/headers.mjs
+++ b/tests/headers.mjs
@@ -112,5 +112,6 @@ checkCached({
 export default {
   name: 'Omit Headers From Cache',
   id: 'headers',
+  description: 'These tests examine how caches omit headers from stored responses and check whether they conform to the existing requirements to omit headers, for example around [no-cache](https://httpwg.org/specs/rfc7234.html#cache-response-directive.no-cache).',
   tests
 };

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -8,10 +8,10 @@ import heuristic from './heuristic-freshness.mjs'
 import statuses from './status.mjs'
 import vary from './vary.mjs'
 import conditional from './conditional.mjs'
-import uncached from './uncached.mjs'
+import headers from './headers.mjs'
 import update304 from './update304.mjs'
 import invalidation from './invalidation.mjs'
 import partial from './partial.mjs'
 import other from './other.mjs'
 
-export default [ccParse, ccFreshness, expiresParse, expires, ccResponse, heuristic, statuses, ccRequest, vary, conditional, uncached, update304, invalidation, partial, other]
+export default [ccParse, ccFreshness, expiresParse, expires, ccResponse, heuristic, statuses, ccRequest, vary, conditional, headers, update304, invalidation, partial, other]

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -8,9 +8,10 @@ import heuristic from './heuristic-freshness.mjs'
 import statuses from './status.mjs'
 import vary from './vary.mjs'
 import conditional from './conditional.mjs'
+import uncached from './uncached.mjs'
 import update304 from './update304.mjs'
 import invalidation from './invalidation.mjs'
 import partial from './partial.mjs'
 import other from './other.mjs'
 
-export default [ccParse, ccFreshness, expiresParse, expires, ccResponse, heuristic, statuses, ccRequest, vary, conditional, update304, invalidation, partial, other]
+export default [ccParse, ccFreshness, expiresParse, expires, ccResponse, heuristic, statuses, ccRequest, vary, conditional, uncached, update304, invalidation, partial, other]

--- a/tests/uncached.mjs
+++ b/tests/uncached.mjs
@@ -1,0 +1,108 @@
+import * as utils from '../utils.mjs';
+
+const tests = [];
+
+function defaultResponseHeaders (validatorType, validatorValue, additionalHeaders) {
+  return [
+    ['Cache-Control', `max-age=3600`],
+    ['Date', 0],
+    [validatorType, validatorValue]
+  ].concat(additionalHeaders);
+}
+
+function checkCached ({name, id, configuredHeaders, expectedHeaders}) {
+  const etag = utils.httpContent(`${id}-etag-1`);
+  const etag1 = `"${etag}"`;
+  const lm1 = utils.httpDate(Date.now(), -24 * 60 * 60);
+  tests.push({
+    name: `${name} with a Last-Modified validator`,
+    id: `uncached-lm-${id}`,
+    requests: [
+      {
+        response_headers: defaultResponseHeaders('Last-Modified', lm1, configuredHeaders),
+        setup: true,
+        pause_after: true,
+      },
+      {
+        expected_type: 'cached',
+        expected_response_headers: expectedHeaders,
+        setup_tests: ['expected_type']
+      }
+    ]
+  });
+  tests.push({
+    name: `${name} with an ETag validator`,
+    id: `uncached-etag-${id}`,
+    requests: [
+      {
+        response_headers: defaultResponseHeaders('ETag', etag1, configuredHeaders),
+        setup: true,
+        pause_after: true,
+      },
+      {
+        expected_type: 'cached',
+        expected_response_headers: expectedHeaders,
+        setup_tests: ['expected_type']
+      }
+    ]
+  });
+}
+
+[
+  ['Test-Header'],
+  ['X-Test-Header'],
+  ['Content-Type', 'text/plain'],
+  ['X-Frame-Options', 'deny'],
+  ['X-XSS-Protection', '1'],
+  ['Clear-Site-Data', 'cookies'],
+  ['Connection'],
+  ['Proxy-Authenticate'],
+  ['Proxy-Connection'],
+  ['Public-Key-Pins'],
+  ['Set-Cookie', 'a=b'],
+  ['Set-Cookie2', 'a=b'],
+  ['Strict-Transport-Security'],
+  ['Strict-Transport-Security2'],
+  ['Trailer'],
+  ['Transfer-Encoding'],
+  ['Upgrade'],
+  ['WWW-Authenticate'],
+].forEach(function ([header, value=null]) {
+  if (value === null) value = utils.httpContent(`${header}-value`);
+  checkCached({
+    name: `HTTP cache must store ${header}`,
+    id: `store-${header}`,
+    configuredHeaders: [[header, value]],
+    expectedHeaders: [[header, value]],
+  });
+});
+
+checkCached({
+  name: `Connection header inhibits caching other headers`,
+  id: `omit-headers-listed-in-Connection`,
+  configuredHeaders: [
+    ['Connection', 'a, b'],
+    ['a', '1'],
+    ['b', '2'],
+    ['c', '3'],
+  ],
+  expectedHeaders: [['c', '3']],
+});
+
+checkCached({
+  name: `Cache-Control:no-cache directive inhibits caching other headers`,
+  id: `omit-headers-listed-in-Cache-Control-no-cache`,
+  configuredHeaders: [
+    ['Cache-Control', 'no-cache="a, b"'],
+    ['a', '1'],
+    ['b', '2'],
+    ['c', '3'],
+  ],
+  expectedHeaders: [['c', '3']],
+});
+
+export default {
+  name: 'Omit Headers From Cache',
+  id: 'uncached',
+  tests
+};

--- a/tests/uncached.mjs
+++ b/tests/uncached.mjs
@@ -10,7 +10,7 @@ function defaultResponseHeaders (validatorType, validatorValue, additionalHeader
   ].concat(additionalHeaders);
 }
 
-function checkCached ({name, id, configuredHeaders, expectedHeaders}) {
+function checkCached ({name, id, configuredHeaders, expectedHeaders, unexpectedHeaders=[]}) {
   const etag = utils.httpContent(`${id}-etag-1`);
   const etag1 = `"${etag}"`;
   const lm1 = utils.httpDate(Date.now(), -24 * 60 * 60);
@@ -26,6 +26,7 @@ function checkCached ({name, id, configuredHeaders, expectedHeaders}) {
       {
         expected_type: 'cached',
         expected_response_headers: expectedHeaders,
+        expected_response_nonheaders: unexpectedHeaders,
         setup_tests: ['expected_type']
       }
     ]
@@ -42,6 +43,7 @@ function checkCached ({name, id, configuredHeaders, expectedHeaders}) {
       {
         expected_type: 'cached',
         expected_response_headers: expectedHeaders,
+        expected_response_nonheaders: unexpectedHeaders,
         setup_tests: ['expected_type']
       }
     ]
@@ -87,6 +89,7 @@ checkCached({
     ['c', '3'],
   ],
   expectedHeaders: [['c', '3']],
+  unexpectedHeaders: ['Connection', 'a', 'b']
 });
 
 checkCached({
@@ -99,6 +102,7 @@ checkCached({
     ['c', '3'],
   ],
   expectedHeaders: [['c', '3']],
+  unexpectedHeaders: ['a', 'b']
 });
 
 export default {


### PR DESCRIPTION
Let me know if these overlap with any existing tests I missed.

On Chrome 74.0.3729.28, I get the following results from this test:

Omit Headers From Cache
Y HTTP cache must store Test-Header with a Last-Modified validator⌾⚙︎
Y HTTP cache must store Test-Header with an ETag validator⌾⚙︎
Y HTTP cache must store X-Test-Header with a Last-Modified validator⌾⚙︎
Y HTTP cache must store X-Test-Header with an ETag validator⌾⚙︎
Y HTTP cache must store Content-Type with a Last-Modified validator⌾⚙︎
Y HTTP cache must store Content-Type with an ETag validator⌾⚙︎
Y HTTP cache must store X-Frame-Options with a Last-Modified validator⌾⚙︎
Y HTTP cache must store X-Frame-Options with an ETag validator⌾⚙︎
Y HTTP cache must store X-XSS-Protection with a Last-Modified validator⌾⚙︎
Y HTTP cache must store X-XSS-Protection with an ETag validator⌾⚙︎
N HTTP cache must store Clear-Site-Data with a Last-Modified validator⌾⚙︎
N HTTP cache must store Clear-Site-Data with an ETag validator⌾⚙︎
N HTTP cache must store Connection with a Last-Modified validator⌾⚙︎
N HTTP cache must store Connection with an ETag validator⌾⚙︎
N HTTP cache must store Proxy-Authenticate with a Last-Modified validator⌾⚙︎
N HTTP cache must store Proxy-Authenticate with an ETag validator⌾⚙︎
N HTTP cache must store Proxy-Connection with a Last-Modified validator⌾⚙︎
N HTTP cache must store Proxy-Connection with an ETag validator⌾⚙︎
N HTTP cache must store Public-Key-Pins with a Last-Modified validator⌾⚙︎
N HTTP cache must store Public-Key-Pins with an ETag validator⌾⚙︎
N HTTP cache must store Set-Cookie with a Last-Modified validator⌾⚙︎
N HTTP cache must store Set-Cookie with an ETag validator⌾⚙︎
N HTTP cache must store Set-Cookie2 with a Last-Modified validator⌾⚙︎
N HTTP cache must store Set-Cookie2 with an ETag validator⌾⚙︎
N HTTP cache must store Strict-Transport-Security with a Last-Modified validator⌾⚙︎
N HTTP cache must store Strict-Transport-Security with an ETag validator⌾⚙︎
Y HTTP cache must store Strict-Transport-Security2 with a Last-Modified validator⌾⚙︎
Y HTTP cache must store Strict-Transport-Security2 with an ETag validator⌾⚙︎
N HTTP cache must store Trailer with a Last-Modified validator⌾⚙︎
N HTTP cache must store Trailer with an ETag validator⌾⚙︎
N HTTP cache must store Transfer-Encoding with a Last-Modified validator⌾⚙︎
N HTTP cache must store Transfer-Encoding with an ETag validator⌾⚙︎
N HTTP cache must store Upgrade with a Last-Modified validator⌾⚙︎
N HTTP cache must store Upgrade with an ETag validator⌾⚙︎
N HTTP cache must store WWW-Authenticate with a Last-Modified validator⌾⚙︎
N HTTP cache must store WWW-Authenticate with an ETag validator⌾⚙︎
N Connection header inhibits caching other headers with a Last-Modified validator⌾⚙︎
N Connection header inhibits caching other headers with an ETag validator⌾⚙︎
✅ Cache-Control:no-cache directive inhibits caching other headers with a Last-Modified validator⌾⚙︎
🔹 Cache-Control:no-cache directive inhibits caching other headers with an ETag validator⌾⚙︎
40 tests, 13 passed.