### PR TITLE
add script for exporting test specs as JSON

### DIFF
--- a/export.mjs
+++ b/export.mjs
@@ -1,0 +1,6 @@
+import tests from './tests/index.mjs'
+import surrogate from './tests/surrogate-control.mjs'
+
+tests.push(surrogate)
+
+console.log(JSON.stringify(tests, null, 2))

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "server": "node server.js",
     "cli": "node --experimental-modules --no-warnings cli.mjs",
+    "export": "node --experimental-modules --no-warnings export.mjs",
     "lint": "standard --fix *.js *.mjs   tests/*.mjs"
   },
   "config": {


### PR DESCRIPTION
This allows testing caches which are neither HTTP proxies nor capable of executing JavaScript.