### PR TITLE
Make tests fully self-contained and constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ The `tests` member is an array of objects, with the following members:
 
 Possible members of a request object:
 
-- `template` - A template object for the request, by name -- see `templates.js`.
 - `request_method` - A string containing the HTTP method to be used.
 - `request_headers` - An array of `[header_name_string, header_value_string]` arrays to
                     emit in the request.
@@ -235,3 +234,4 @@ Possible members of a request object:
 test fetches have run, this state is retrieved and the expected_* lists are checked, including
 their length.
 
+For convenience and clarity when writing tests, there are some request templates available in `templates.mjs`. Each template is a function which accepts a request object, as defined above, and returns a new request object. Any fields in the template are added to the request object unless a field of the same name is already present.

--- a/README.md
+++ b/README.md
@@ -217,10 +217,11 @@ Possible members of a request object:
                               headers to check the request for on the server, or an array of
                               strings representing header names to check for presence in the
                               request.
-- `expected_response_headers` - An array of `[header_name_string, header_value_string]` representing
-                              headers to check the response for on the client, or an array of
-                              strings representing header names to check for presence in the
-                              response. See also response_headers.
+- `expected_response_headers` - An array of any combination of the following. See also `response_headers`.
+  - `header_name_string`: assert that the named header is present
+  - `[header_name_string, header_value_string]`: assert that the header has the given value
+  - `[header_name_string, '=', other_header_name]`: assert that the two headers have the same value
+  - `[header_name_string, '>', number]`: assert that the header's value is numerically greater than specified
 - `expected_response_headers_missing` - An array of `header_name_string` representing headers to
                                       check that the response on the client does not include.
 - `expected_response_text` - A string to check the response body against on the client.

--- a/client.mjs
+++ b/client.mjs
@@ -1,5 +1,4 @@
 
-import templates from './templates.mjs'
 import * as utils from './utils.mjs'
 
 const noBodyStatus = new Set([204, 304])
@@ -133,14 +132,6 @@ function expandTemplates (test) {
     request.name = test.name
     request.id = test.id
     request.dump = test.dump
-    if ('template' in request) {
-      var template = templates[request['template']]
-      for (let member in template) {
-        if (!request.hasOwnProperty(member)) {
-          request[member] = template[member]
-        }
-      }
-    }
     requests.push(request)
   }
   return requests

--- a/client.mjs
+++ b/client.mjs
@@ -220,9 +220,26 @@ function makeCheckResponse (idx, reqConfig, dump) {
         if (typeof header === 'string') {
           assert(respPresentSetup, response.headers.has(header),
             `Response ${reqNum} ${header} header not present.`)
-        } else if (typeof header[1] === 'function') {
-          var prefix = `Response ${reqNum} header ${header[0]}`
-          header[1](respPresentSetup, assert, prefix, response.headers.get(header[0]), response)
+        } else if (header.length > 2) {
+          assert(respPresentSetup, response.headers.has(header[0]),
+            `Response ${reqNum} ${header[0]} header not present.`)
+
+          const value = response.headers.get(header[0])
+          let msg, condition
+          if (header[1] === '=') {
+            const expected = response.headers.get(header[2])
+            condition = value === expected
+            msg = `match ${header[2]} (${expected})`
+          } else if (header[1] === '>') {
+            const expected = header[2]
+            condition = parseInt(value) > expected
+            msg = `be bigger than ${expected}`
+          } else {
+            throw new Error(`Unknown expected-header operator '${header[1]}'`)
+          }
+
+          assert(respPresentSetup, condition,
+            `Response ${reqNum} header ${header[0]} is ${value}, should ${msg}`)
         } else {
           assert(respPresentSetup, response.headers.get(header[0]) === header[1],
             `Response ${reqNum} header ${header[0]} is "${response.headers.get(header[0])}", not "${header[1]}"`)

--- a/results/apache.json
+++ b/results/apache.json
@@ -381,7 +381,7 @@
   "other-cookie": true,
   "other-date-update": [
     "Assertion",
-    "Response 2 header Date is Tue, 04 Feb 2020 09:19:19 GMT, should be Tue, 04 Feb 2020 09:19:16 GMT"
+    "Response 2 header Date is Tue, 11 Feb 2020 17:30:16 GMT, should match Server-Now (Tue, 11 Feb 2020 17:30:13 GMT)"
   ],
   "other-set-cookie": true,
   "other-warning": [
@@ -582,11 +582,11 @@
     "Response 2 does not come from cache"
   ],
   "vary-syntax-star-star": [
-    "FetchError",
-    "request to http://localhost:8004/config/d5c28cca-9d95-41e6-883b-7615076ff5a5 failed, reason: connect ECONNRESET 127.0.0.1:8004"
+    "Assertion",
+    "Response 2 does not come from cache"
   ],
   "vary-syntax-star-star-lines": [
-    "FetchError",
-    "request to http://localhost:8004/config/8c1fb144-480a-475e-aa60-2941d2cb7265 failed, reason: connect ECONNRESET 127.0.0.1:8004"
+    "Assertion",
+    "Response 2 does not come from cache"
   ]
 }

--- a/results/chrome.json
+++ b/results/chrome.json
@@ -438,15 +438,15 @@
   ],
   "other-age-gen": [
     "Assertion",
-    "Response 2 header Age is null, should be bigger"
+    "Response 2 Age header not present."
   ],
   "other-age-update-expires": [
     "Assertion",
-    "Response 2 header Age is 30, should be bigger"
+    "Response 2 header Age is 30, should be bigger than 32"
   ],
   "other-age-update-max-age": [
     "Assertion",
-    "Response 2 header Age is 30, should be bigger"
+    "Response 2 header Age is 30, should be bigger than 32"
   ],
   "other-cookie": true,
   "other-date-update": true,

--- a/results/firefox.json
+++ b/results/firefox.json
@@ -366,15 +366,15 @@
   "invalidate-PUT-location": true,
   "other-age-gen": [
     "Assertion",
-    "Response 2 header Age is null, should be bigger"
+    "Response 2 Age header not present."
   ],
   "other-age-update-expires": [
     "Assertion",
-    "Response 2 header Age is 30, should be bigger"
+    "Response 2 header Age is 30, should be bigger than 32"
   ],
   "other-age-update-max-age": [
     "Assertion",
-    "Response 2 header Age is 30, should be bigger"
+    "Response 2 header Age is 30, should be bigger than 32"
   ],
   "other-cookie": true,
   "other-date-update": true,

--- a/results/nginx.json
+++ b/results/nginx.json
@@ -29,7 +29,7 @@
   ],
   "304-etag-update-response-Expires": [
     "Assertion",
-    "Response 2 header Expires is \"Tue, 04 Feb 2020 09:21:10 GMT\", not \"Tue, 04 Feb 2020 10:21:09 GMT\""
+    "Response 2 header Expires is \"Fri, 01 Jan 2038 01:01:01 GMT\", not \"Mon, 11 Jan 2038 11:11:11 GMT\""
   ],
   "304-etag-update-response-Public-Key-Pins": [
     "Assertion",
@@ -93,7 +93,7 @@
   ],
   "304-etag-update-stored-Expires": [
     "Assertion",
-    "Response 3 header Expires is \"Tue, 04 Feb 2020 09:21:10 GMT\", not \"Tue, 04 Feb 2020 10:21:09 GMT\""
+    "Response 3 header Expires is \"Fri, 01 Jan 2038 01:01:01 GMT\", not \"Mon, 11 Jan 2038 11:11:11 GMT\""
   ],
   "304-etag-update-stored-Public-Key-Pins": [
     "Assertion",
@@ -157,7 +157,7 @@
   ],
   "304-lm-update-response-Expires": [
     "Assertion",
-    "Response 2 header Expires is \"Tue, 04 Feb 2020 09:21:10 GMT\", not \"Tue, 04 Feb 2020 10:21:09 GMT\""
+    "Response 2 header Expires is \"Fri, 01 Jan 2038 01:01:01 GMT\", not \"Mon, 11 Jan 2038 11:11:11 GMT\""
   ],
   "304-lm-update-response-Public-Key-Pins": [
     "Assertion",
@@ -221,7 +221,7 @@
   ],
   "304-lm-update-stored-Expires": [
     "Assertion",
-    "Response 3 header Expires is \"Tue, 04 Feb 2020 09:21:10 GMT\", not \"Tue, 04 Feb 2020 10:21:09 GMT\""
+    "Response 3 header Expires is \"Fri, 01 Jan 2038 01:01:01 GMT\", not \"Mon, 11 Jan 2038 11:11:11 GMT\""
   ],
   "304-lm-update-stored-Public-Key-Pins": [
     "Assertion",
@@ -240,8 +240,8 @@
     "Response 3 header Test-Header is \"AAAAAAAAAAAAAAA\", not \"ABCDEFGHIJKLMNO\""
   ],
   "304-lm-update-stored-X-Content-Foo": [
-    "FetchError",
-    "request to http://localhost:8002/config/fc7b84f3-d33a-41ad-b6c0-188ed2ec2f44 failed, reason: connect ECONNRESET 127.0.0.1:8002"
+    "Assertion",
+    "Response 3 header X-Content-Foo is \"AZYXWVUTSRQPONM\", not \"AAAAAAAAAAAAAAA\""
   ],
   "304-lm-update-stored-X-Frame-Options": [
     "Assertion",
@@ -587,20 +587,20 @@
   ],
   "other-age-gen": [
     "Assertion",
-    "Response 2 header Age is null, should be bigger"
+    "Response 2 Age header not present."
   ],
   "other-age-update-expires": [
     "Assertion",
-    "Response 2 header Age is 30, should be bigger"
+    "Response 2 header Age is 30, should be bigger than 32"
   ],
   "other-age-update-max-age": [
     "Assertion",
-    "Response 2 header Age is 30, should be bigger"
+    "Response 2 header Age is 30, should be bigger than 32"
   ],
   "other-cookie": true,
   "other-date-update": [
     "Assertion",
-    "Response 2 header Date is Tue, 04 Feb 2020 09:21:14 GMT, should be Tue, 04 Feb 2020 09:21:10 GMT"
+    "Response 2 header Date is Tue, 11 Feb 2020 17:30:01 GMT, should match Server-Now (Tue, 11 Feb 2020 17:29:58 GMT)"
   ],
   "other-set-cookie": [
     "Assertion",

--- a/results/trafficserver.json
+++ b/results/trafficserver.json
@@ -148,13 +148,10 @@
   "ccreq-no-cache-etag": true,
   "ccreq-no-cache-lm": true,
   "ccreq-no-store": [
-    "FetchError",
-    "request to http://localhost:8003/config/e666089d-49ad-4b40-a2da-609e8d00daef failed, reason: connect ECONNRESET 127.0.0.1:8003"
+    "Assertion",
+    "Response 2 comes from cache"
   ],
-  "ccreq-oic": [
-    "FetchError",
-    "request to http://localhost:8003/config/94a11fea-f777-4482-a009-92418052b509 failed, reason: connect ECONNRESET 127.0.0.1:8003"
-  ],
+  "ccreq-oic": true,
   "conditional-304-etag": true,
   "conditional-etag-forward": [
     "Assertion",
@@ -303,7 +300,7 @@
   "headers-store-Test-Header": true,
   "headers-store-Transfer-Encoding": [
     "Setup",
-    "Response body is \"24\r\n2818d650-b94d-4b45-9a82-8d9cf9da5b80\r\n0\r\n\r\n\", not \"2818d650-b94d-4b45-9a82-8d9cf9da5b80\""
+    "Response body is \"24\r\na7aac498-9ecf-45c6-b53d-4da6006379b5\r\n0\r\n\r\n\", not \"a7aac498-9ecf-45c6-b53d-4da6006379b5\""
   ],
   "headers-store-Upgrade": [
     "Assertion",
@@ -435,14 +432,8 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "pragma-request-extension": [
-    "FetchError",
-    "request to http://localhost:8003/config/2a272841-09d2-47f5-9bcf-724f17c10aa1 failed, reason: connect ECONNRESET 127.0.0.1:8003"
-  ],
-  "pragma-request-no-cache": [
-    "FetchError",
-    "request to http://localhost:8003/config/f73c6b81-9224-431a-a2e9-9497085ac89f failed, reason: connect ECONNRESET 127.0.0.1:8003"
-  ],
+  "pragma-request-extension": true,
+  "pragma-request-no-cache": true,
   "pragma-response-extension": true,
   "pragma-response-no-cache": [
     "Assertion",

--- a/results/varnish.json
+++ b/results/varnish.json
@@ -55,10 +55,7 @@
   "304-lm-update-response-X-Content-Foo": true,
   "304-lm-update-response-X-Frame-Options": true,
   "304-lm-update-response-X-Test-Header": true,
-  "304-lm-update-response-X-XSS-Protection": [
-    "FetchError",
-    "request to http://localhost:8005/config/95feeb50-417c-4c0b-a13d-9dc5da50f938 failed, reason: connect ECONNRESET 127.0.0.1:8005"
-  ],
+  "304-lm-update-response-X-XSS-Protection": true,
   "304-lm-update-stored-Cache-Control": true,
   "304-lm-update-stored-Clear-Site-Data": true,
   "304-lm-update-stored-Content-Foo": true,

--- a/templates.mjs
+++ b/templates.mjs
@@ -1,52 +1,60 @@
-
-export default {
-  'fresh': {
-    'response_headers': [
-      ['Expires', 100000],
-      ['Last-Modified', 0],
-      ['Date', 0]
-    ]
-  },
-  'stale': {
-    'response_headers': [
-      ['Expires', -5000],
-      ['Last-Modified', -100000],
-      ['Date', 0]
-    ]
-  },
-  'lcl_response': {
-    'response_headers': [
-      ['Location', 'location_target'],
-      ['Content-Location', 'content_location_target']
-    ],
-    magic_locations: true
-  },
-  'location': {
-    'filename': 'location_target',
-    'response_headers': [
-      ['Expires', 100000],
-      ['Last-Modified', 0],
-      ['Date', 0]
-    ]
-  },
-  'content_location': {
-    'filename': 'content_location_target',
-    'response_headers': [
-      ['Expires', 100000],
-      ['Last-Modified', 0],
-      ['Date', 0]
-    ]
-  },
-  'vary-setup': {
-    request_headers: [
-      ['Foo', '1']
-    ],
-    response_headers: [
-      ['Expires', 5000],
-      ['Last-Modified', -3000],
-      ['Date', 0],
-      ['Vary', 'Foo']
-    ],
-    setup: true
+function make_template (template) {
+  return function (request) {
+    return Object.assign({}, template, request)
   }
 }
+
+export const fresh = make_template({
+  'response_headers': [
+    ['Expires', 100000],
+    ['Last-Modified', 0],
+    ['Date', 0]
+  ]
+})
+
+export const stale = make_template({
+  'response_headers': [
+    ['Expires', -5000],
+    ['Last-Modified', -100000],
+    ['Date', 0]
+  ]
+})
+
+export const lcl_response = make_template({
+  'response_headers': [
+    ['Location', 'location_target'],
+    ['Content-Location', 'content_location_target']
+  ],
+  magic_locations: true
+})
+
+export const location = make_template({
+  'filename': 'location_target',
+  'response_headers': [
+    ['Expires', 100000],
+    ['Last-Modified', 0],
+    ['Date', 0]
+  ]
+})
+
+export const content_location = make_template({
+  'filename': 'content_location_target',
+  'response_headers': [
+    ['Expires', 100000],
+    ['Last-Modified', 0],
+    ['Date', 0]
+  ]
+})
+
+export const vary_setup = make_template({
+  request_headers: [
+    ['Foo', '1']
+  ],
+  response_headers: [
+    ['Expires', 5000],
+    ['Last-Modified', -3000],
+    ['Date', 0],
+    ['Vary', 'Foo']
+  ],
+  setup: true
+})

--- a/tests/cc-request.mjs
+++ b/tests/cc-request.mjs
@@ -1,3 +1,5 @@
+
+import * as templates from '../templates.mjs'
 import * as utils from '../utils.mjs'
 
 export default {
@@ -10,11 +12,10 @@ export default {
       id: 'ccreq-ma0',
       kind: 'check',
       requests: [
-        {
-          template: 'fresh',
+        templates.fresh({
           pause_after: true,
           setup: true
-        },
+        }),
         {
           request_headers: [
             ['Cache-Control', 'max-age=0']
@@ -28,11 +29,10 @@ export default {
       id: 'ccreq-ma1',
       kind: 'check',
       requests: [
-        {
-          template: 'fresh',
+        templates.fresh({
           pause_after: true,
           setup: true
-        },
+        }),
         {
           request_headers: [
             ['Cache-Control', 'max-age=1']

--- a/tests/invalidation.mjs
+++ b/tests/invalidation.mjs
@@ -1,4 +1,6 @@
 
+import * as templates from '../templates.mjs'
+
 var tests = []
 
 function checkInvalidation (method) {
@@ -6,10 +8,9 @@ function checkInvalidation (method) {
     name: `HTTP cache must invalidate the URL after a successful response to a \`${method}\` request`,
     id: `invalidate-${method}`,
     requests: [
-      {
-        template: 'fresh',
+      templates.fresh({
         setup: true
-      }, {
+      }), {
         request_method: method,
         request_body: 'abc',
         setup: true
@@ -24,10 +25,9 @@ function checkInvalidation (method) {
     kind: 'optimal',
     depends_on: [`invalidate-${method}`],
     requests: [
-      {
-        template: 'fresh',
+      templates.fresh({
         setup: true
-      }, {
+      }), {
         request_method: method,
         request_body: 'abc',
         response_status: [500, 'Internal Server Error'],
@@ -44,18 +44,15 @@ function checkLocationInvalidation (method) {
     name: `HTTP cache must invalidate \`Location\` URL after a successful response to a \`${method}\` request`,
     id: `invalidate-${method}-location`,
     requests: [
-      {
-        template: 'location',
+      templates.location({
         setup: true
-      }, {
+      }), templates.lcl_response({
         request_method: 'POST',
         request_body: 'abc',
-        template: 'lcl_response',
         setup: true
-      }, {
-        template: 'location',
+      }), templates.location({
         expected_type: 'not_cached'
-      }
+      })
     ]
   })
 }
@@ -65,18 +62,15 @@ function checkClInvalidation (method) {
     name: `HTTP cache must invalidate \`Content-Location\` URL after a successful response to a \`${method}\` request`,
     id: `invalidate-${method}-cl`,
     requests: [
-      {
-        template: 'content_location',
+      templates.content_location({
         setup: true
-      }, {
+      }), templates.lcl_response({
         request_method: method,
         request_body: 'abc',
-        template: 'lcl_response',
         setup: true
-      }, {
-        template: 'content_location',
+      }), templates.content_location({
         expected_type: 'not_cached'
-      }
+      })
     ]
   })
 }

--- a/tests/other.mjs
+++ b/tests/other.mjs
@@ -24,10 +24,7 @@ export default
         {
           expected_type: 'cached',
           expected_response_headers: [
-            ['Age', function (s, assert, p, a) {
-              assert(s, a !== undefined, `${p} isn't present`)
-              assert(s, parseInt(a) > 2, `${p} is ${a}, should be bigger`)
-            }]
+            ['Age', '>', 2]
           ]
         }
       ]
@@ -48,10 +45,7 @@ export default
         {
           expected_type: 'cached',
           expected_response_headers: [
-            ['Age', function (s, assert, p, a) {
-              assert(s, a !== undefined, `${p} isn't present`)
-              assert(s, parseInt(a) > 32, `${p} is ${a}, should be bigger`)
-            }]
+            ['Age', '>', 32]
           ]
         }
       ]
@@ -72,10 +66,7 @@ export default
         {
           expected_type: 'cached',
           expected_response_headers: [
-            ['Age', function (s, assert, p, a) {
-              assert(s, a !== undefined, `${p} isn't present`)
-              assert(s, parseInt(a) > 32, `${p} is ${a}, should be bigger`)
-            }]
+            ['Age', '>', 32]
           ]
         }
       ]
@@ -95,9 +86,7 @@ export default
         {
           expected_type: 'cached',
           expected_response_headers: [
-            ['Date', function (s, assert, p, a, r) {
-              assert(s, a === r.headers.get('Server-Now'), `${p} is ${a}, should be ${r.headers.get('Server-Now')}`)
-            }]
+            ['Date', '=', 'Server-Now']
           ]
         }
       ]

--- a/tests/other.mjs
+++ b/tests/other.mjs
@@ -1,3 +1,5 @@
+
+import * as templates from '../templates.mjs'
 import * as utils from '../utils.mjs'
 
 export default
@@ -104,10 +106,9 @@ export default
       name: 'Different query arguments must be different cache keys',
       id: 'query-args-different',
       requests: [
-        {
-          template: 'fresh',
+        templates.fresh({
           query_arg: 'test=' + utils.httpContent('query-args-different-1')
-        },
+        }),
         {
           query_arg: 'test=' + utils.httpContent('query-args-different-2'),
           expected_type: 'not_cached'
@@ -119,10 +120,9 @@ export default
       id: 'query-args-same',
       kind: 'optimal',
       requests: [
-        {
-          template: 'fresh',
+        templates.fresh({
           query_arg: 'test=' + utils.httpContent('query-args-same')
-        },
+        }),
         {
           query_arg: 'test=' + utils.httpContent('query-args-same'),
           expected_type: 'cached'
@@ -170,9 +170,7 @@ export default
       id: 'other-warning',
       kind: 'check',
       requests: [
-        {
-          template: 'stale'
-        },
+        templates.stale({}),
         {
           expected_response_headers: ['warning']
         }

--- a/tests/status.mjs
+++ b/tests/status.mjs
@@ -1,3 +1,5 @@
+
+import * as templates from '../templates.mjs'
 import * as utils from '../utils.mjs'
 
 var tests = []
@@ -14,13 +16,12 @@ function checkStatus (status) {
     id: `status-${code}-stale`,
     depends_on: [`status-${code}-fresh`],
     requests: [
-      {
-        template: 'stale',
+      templates.stale({
         response_status: [code, phrase],
         response_body: body,
         redirect: 'manual',
         setup: true
-      }, {
+      }), {
         expected_type: 'not_cached',
         redirect: 'manual',
         response_body: body
@@ -32,13 +33,12 @@ function checkStatus (status) {
     id: `status-${code}-fresh`,
     kind: 'optimal',
     requests: [
-      {
-        template: 'fresh',
+      templates.fresh({
         response_status: [code, phrase],
         response_body: body,
         redirect: 'manual',
         setup: true
-      }, {
+      }), {
         expected_type: 'cached',
         response_status: [code, phrase],
         redirect: 'manual',

--- a/tests/update304.mjs
+++ b/tests/update304.mjs
@@ -4,7 +4,7 @@ var tests = []
 
 var header = 'Test-Header'
 var valueA = utils.httpContent(`${header}-value-A`)
-var lm1 = utils.httpDate(Date.now(), -24 * 60 * 60)
+var lm1 = "Wed, 01 Jan 2020 00:00:00 GMT"
 tests.push({
   name: `HTTP cache must return stored \`${header}\` from a \`304\` that omits it`,
   id: `304-lm-use-stored-${header}`,
@@ -40,7 +40,7 @@ function check304 (args) {
   var valueB = args[2] || utils.httpContent(`${header}-value-B`)
   var etag = utils.httpContent(`${header}-etag-1`)
   var etag1 = `"${etag}"`
-  var lm1 = utils.httpDate(Date.now(), -24 * 60 * 60)
+  var lm1 = "Wed, 01 Jan 2020 00:00:00 GMT"
 
   tests.push({
     name: `HTTP cache must update returned \`${header}\` from a \`Last-Modified 304\``,
@@ -156,7 +156,7 @@ function makeResponse (header, value, lifetime, validatorType, validatorValue) {
   ['X-Frame-Options', 'deny', 'sameorigin'],
   ['X-XSS-Protection', '1', '1; mode=block'],
   ['Cache-Control', 'max-age=1', 'max-age=3600'],
-  ['Expires', utils.httpDate(Date.now(), 1), utils.httpDate(Date.now(), 3600)],
+  ['Expires', 'Fri, 01 Jan 2038 01:01:01 GMT', 'Mon, 11 Jan 2038 11:11:11 GMT'],
   ['Clear-Site-Data', 'cache', 'cookies'],
   ['Public-Key-Pins'],
   ['Set-Cookie', 'a=b', 'a=c'],

--- a/tests/vary.mjs
+++ b/tests/vary.mjs
@@ -1,3 +1,5 @@
+
+import * as templates from '../templates.mjs'
 import * as utils from '../utils.mjs'
 
 export default {
@@ -10,9 +12,7 @@ export default {
       id: 'vary-match',
       kind: 'optimal',
       requests: [
-        {
-          template: 'vary-setup'
-        },
+        templates.vary_setup({}),
         {
           request_headers: [
             ['Foo', '1']
@@ -25,9 +25,7 @@ export default {
       name: "HTTP cache must not reuse `Vary` response when request doesn't match",
       id: 'vary-no-match',
       requests: [
-        {
-          template: 'vary-setup'
-        },
+        templates.vary_setup({}),
         {
           request_headers: [
             ['Foo', '2']
@@ -40,9 +38,7 @@ export default {
       name: 'HTTP cache must not reuse `Vary` response when request omits variant request header',
       id: 'vary-omit',
       requests: [
-        {
-          template: 'vary-setup'
-        },
+        templates.vary_setup({}),
         {
           expected_type: 'not_cached'
         }
@@ -53,10 +49,9 @@ export default {
       id: 'vary-invalidate',
       kind: 'optimal',
       requests: [
-        {
-          template: 'vary-setup',
+        templates.vary_setup({
           response_body: utils.httpContent('foo_1')
-        },
+        }),
         {
           request_headers: [
             ['Foo', '2']
@@ -85,13 +80,12 @@ export default {
       id: 'vary-cache-key',
       kind: 'optimal',
       requests: [
-        {
-          template: 'vary-setup',
+        templates.vary_setup({
           request_headers: [
             ['Foo', '1'],
             ['Other', '2']
           ]
-        },
+        }),
         {
           request_headers: [
             ['Foo', '1'],

--- a/utils.mjs
+++ b/utils.mjs
@@ -44,10 +44,6 @@ export function httpContent (csKey, contentLength = 15) {
   }
 }
 
-export function httpDate (now, deltaSecs) {
-  return new Date(now + (deltaSecs * 1000)).toGMTString()
-}
-
 export function token () {
   var uuid = [toHex(randInt(32), 8),
     toHex(randInt(16), 4),


### PR DESCRIPTION
Thanks for merging my previous PR!

Exporting the tests as JSON was a little more involved than I realized due to three reasons:

1. The `update304` tests tried to set `Last-Modified` and `Expires` according to when the tests were run, which got hard-coded into the JSON export.

2. I didn't notice the `template` option, so the export didn't have the complete configuration for requests which used templates. (I especially like my fix for this one, which also helps with tracking down typos in the test specifications.)

3. A handful of tests stored functions in `expected_response_headers`, but functions export as `null` from `JSON.stringify`.

This pull request fixes each of these in separate commits, then updates the `results/` for everything I had available to test locally. The diff of the results shows that the changes I made to the tests didn't change whether any tests passed.

I tried to check over the tests more carefully this time to see if anything else might cause issues for JSON export, and I couldn't find any other potential issues. But if you can think of anything I should look more closely at I'd appreciate any pointers.