### PR TITLE
Support forward proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ To test a browser, just point it at `https://{hostname:port}/test-browser.html` 
 
 On OSX, you can use `test-browser.sh` to automate this.
 
+## Testing Forward Proxies
+To test a forward proxy which listens on 127.0.0.1:8082, start the server:
+
+> npm run server
+
+and then run:
+
+> HTTP_PROXY=http://127.0.0.1:8082 npm run --silent cli --base=http://127.0.0.1:8000
 
 ## Interpreting the Results
 

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,7 +1,7 @@
 import { runTests, getResults } from './client/runner.mjs'
 import * as display from './lib/display.mjs'
 import { GREEN, NC } from './lib/defines.mjs'
-import fetch from 'node-fetch'
+import fetch from 'node-fetch-with-proxy'
 import tests from './tests/index.mjs'
 import surrogate from './tests/surrogate-control.mjs'
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "liquidjs": "^9.16.1",
     "marked": "^4.0.12",
     "node-fetch": "3.1.1",
+    "node-fetch-with-proxy": "^0.1.6",
     "npm": "^6.14.11"
   },
   "scripts": {


### PR DESCRIPTION
This change allows testing of caching http forward proxies by setting HTTP_PROXY env variable