### PR TITLE
Fix scoping of testArray

### DIFF
--- a/test-engine/client/runner.mjs
+++ b/test-engine/client/runner.mjs
@@ -5,7 +5,7 @@ export async function runTests (tests, myFetch, browserCache, base, chunkSize = 
   config.setFetch(myFetch)
   config.setBaseUrl(base)
   config.setUseBrowserCache(browserCache)
-  
+
   const testArray = []
   tests.forEach(testSet => {
     testSet.tests.forEach(test => {

--- a/test-engine/client/runner.mjs
+++ b/test-engine/client/runner.mjs
@@ -1,12 +1,12 @@
 import * as config from './config.mjs'
 import { makeTest, testResults } from './test.mjs'
 
-const testArray = []
-
 export async function runTests (tests, myFetch, browserCache, base, chunkSize = 50) {
   config.setFetch(myFetch)
   config.setBaseUrl(base)
   config.setUseBrowserCache(browserCache)
+  
+  const testArray = []
   tests.forEach(testSet => {
     testSet.tests.forEach(test => {
       if (test.id === undefined) throw new Error('Missing test id')


### PR DESCRIPTION
Changes the scope of testArray to be initialized within the only place it's used. Allows for running `runTests` multiple times within the same process