### PR TITLE
Add tests for interim response handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,9 @@ Possible members of a request object:
                      `false`.
 - `response_body` - String to send as the response body from the origin. Defaults to
                   the test identifier.
+- `interim_responses` - An array of interim responses to send before the final response. Each item can be either:
+  - `[status_code]` - Just a status code (e.g., `[102]`)
+  - `[status_code, headers_array]` - Status code and headers, where headers_array is an array of `[header_name, header_value]` pairs
 - `response_pause` - Integer number of seconds for the server to pause before generating a response.
 - `check_body` - Whether to check the response body. Default `true`.
 - `expected_type` - One of:
@@ -98,6 +101,7 @@ Possible members of a request object:
   - `header_name_string` representing headers to check that the response on the client does not include.
   - `[header_name_string, header_value_string]`: headers to check that the response is either missing, or if they're present, that they do _not_ contain the given value string (evaluated against the whole header value).
 - `expected_response_text` - A string to check the response body against on the client.
+- `expected_interim_responses` - An array of interim responses expected to be received by the client. Format is the same as `interim_responses`.
 - `setup` - Boolean to indicate whether this is a setup request; failures don't mean the actual test failed.
 - `setup_tests` - Array of values that indicate whether the specified check is part of setup; failures don't mean the actual test failed. One of: `["expected_type", "expected_method", "expected_status", "expected_response_headers", "expected_response_text", "expected_request_headers"]`
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -9,5 +9,6 @@ server {
         proxy_pass http://localhost:8000;
         proxy_cache my-cache;
         proxy_cache_revalidate on;
+        proxy_http_version 1.1;
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "liquidjs": "^10.9.2",
     "marked": "^15.0.0",
-    "npm": "^11.0.0"
+    "npm": "^11.0.0",
+    "undici": "^7.4.0"
   },
   "scripts": {
     "server": "node test-engine/server/server.mjs",

--- a/results/apache.json
+++ b/results/apache.json
@@ -425,6 +425,8 @@
   "heuristic-delta-86400": true,
   "interim-102": true,
   "interim-103": true,
+  "interim-no-header-reuse": true,
+  "interim-not-cached": true,
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": [
     "Assertion",

--- a/results/apache.json
+++ b/results/apache.json
@@ -423,6 +423,8 @@
   "heuristic-delta-60": true,
   "heuristic-delta-600": true,
   "heuristic-delta-86400": true,
+  "interim-102": true,
+  "interim-103": true,
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": [
     "Assertion",

--- a/results/caddy.json
+++ b/results/caddy.json
@@ -545,6 +545,14 @@
     "Assertion",
     "Interim response 1 not received"
   ],
+  "interim-no-header-reuse": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
+  "interim-not-cached": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": [
     "Assertion",

--- a/results/caddy.json
+++ b/results/caddy.json
@@ -537,6 +537,14 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
+  "interim-102": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
+  "interim-103": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": [
     "Assertion",

--- a/results/haproxy.json
+++ b/results/haproxy.json
@@ -522,6 +522,10 @@
   "heuristic-delta-60": true,
   "heuristic-delta-600": true,
   "heuristic-delta-86400": true,
+  "interim-102": true,
+  "interim-103": true,
+  "interim-no-header-reuse": true,
+  "interim-not-cached": true,
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": [
     "Assertion",

--- a/results/nginx.json
+++ b/results/nginx.json
@@ -569,6 +569,14 @@
     "Response 2 does not come from cache"
   ],
   "interim-103": [
+    "AbortError",
+    "This operation was aborted"
+  ],
+  "interim-no-header-reuse": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "interim-not-cached": [
     "Assertion",
     "Response 2 does not come from cache"
   ],

--- a/results/nginx.json
+++ b/results/nginx.json
@@ -564,6 +564,14 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
+  "interim-102": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "interim-103": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
   "invalidate-DELETE": [
     "Assertion",
     "Response 3 comes from cache"

--- a/results/squid.json
+++ b/results/squid.json
@@ -438,6 +438,8 @@
   "heuristic-delta-60": true,
   "heuristic-delta-600": true,
   "heuristic-delta-86400": true,
+  "interim-102": true,
+  "interim-103": true,
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": true,
   "invalidate-DELETE-failed": true,

--- a/results/squid.json
+++ b/results/squid.json
@@ -440,6 +440,8 @@
   "heuristic-delta-86400": true,
   "interim-102": true,
   "interim-103": true,
+  "interim-no-header-reuse": true,
+  "interim-not-cached": true,
   "invalidate-DELETE": true,
   "invalidate-DELETE-cl": true,
   "invalidate-DELETE-failed": true,

--- a/results/trafficserver.json
+++ b/results/trafficserver.json
@@ -464,6 +464,14 @@
     "Assertion",
     "Interim response 1 not received"
   ],
+  "interim-no-header-reuse": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
+  "interim-not-cached": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
   "invalidate-DELETE": [
     "Setup",
     "Response 2 status is 403, not 200"

--- a/results/trafficserver.json
+++ b/results/trafficserver.json
@@ -456,6 +456,14 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
+  "interim-102": [
+    "AbortError",
+    "This operation was aborted"
+  ],
+  "interim-103": [
+    "Assertion",
+    "Interim response 1 not received"
+  ],
   "invalidate-DELETE": [
     "Setup",
     "Response 2 status is 403, not 200"

--- a/results/varnish.json
+++ b/results/varnish.json
@@ -506,6 +506,14 @@
     "Setup",
     "Response 1 status is 503, not 200"
   ],
+  "interim-no-header-reuse": [
+    "Setup",
+    "Response 1 status is 503, not 200"
+  ],
+  "interim-not-cached": [
+    "Setup",
+    "Response 1 status is 503, not 200"
+  ],
   "invalidate-DELETE": [
     "Assertion",
     "Response 3 comes from cache"

--- a/results/varnish.json
+++ b/results/varnish.json
@@ -498,6 +498,14 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
+  "interim-102": [
+    "Setup",
+    "Response 1 status is 503, not 200"
+  ],
+  "interim-103": [
+    "Setup",
+    "Response 1 status is 503, not 200"
+  ],
   "invalidate-DELETE": [
     "Assertion",
     "Response 3 comes from cache"

--- a/test-engine/client/test.mjs
+++ b/test-engine/client/test.mjs
@@ -37,8 +37,7 @@ export async function makeTest (test) {
         if ('expected_interim_responses' in reqConfig) {
           // Dynamic import since undici is only available in Node.js
           const undici = await import('undici')
-          const globalDispatcher = undici.getGlobalDispatcher()
-          const dispatcher = globalDispatcher.compose(clientUtils.interimResponsesCollectingInterceptor(interimResponses))
+          const dispatcher = new undici.Agent().compose(clientUtils.interimResponsesCollectingInterceptor(interimResponses))
           init.dispatcher = dispatcher
         }
 

--- a/test-engine/client/test.mjs
+++ b/test-engine/client/test.mjs
@@ -97,7 +97,7 @@ function checkResponse (test, requests, idx, response, interimResponses) {
   const reqNum = idx + 1
   const reqConfig = requests[idx]
   const resNum = parseInt(response.headers.get('Server-Request-Count'))
-  if (test.dump === true) clientUtils.logResponse(response, reqNum)
+  if (test.dump === true) clientUtils.logResponse(response, interimResponses, reqNum)
 
   // catch retries
   if (response.headers.has('Request-Numbers')) {

--- a/test-engine/client/test.mjs
+++ b/test-engine/client/test.mjs
@@ -4,7 +4,6 @@ import * as utils from '../lib/utils.mjs'
 import * as config from './config.mjs'
 import * as clientUtils from './utils.mjs'
 import * as fetching from './fetching.mjs'
-import { getGlobalDispatcher } from 'undici'
 const assert = utils.assert
 const setupCheck = clientUtils.setupCheck
 
@@ -19,7 +18,7 @@ export async function makeTest (test) {
   const fetchFunctions = []
   for (let i = 0; i < requests.length; ++i) {
     fetchFunctions.push({
-      code: idx => {
+      code: async idx => {
         const reqConfig = requests[idx]
         const reqNum = idx + 1
         const url = clientUtils.makeTestUrl(uuid, reqConfig)
@@ -36,7 +35,9 @@ export async function makeTest (test) {
 
         const interimResponses = []
         if ('expected_interim_responses' in reqConfig) {
-          const globalDispatcher = getGlobalDispatcher()
+          // Dynamic import since undici is only available in Node.js
+          const undici = await import('undici')
+          const globalDispatcher = undici.getGlobalDispatcher()
           const dispatcher = globalDispatcher.compose(clientUtils.interimResponsesCollectingInterceptor(interimResponses))
           init.dispatcher = dispatcher
         }

--- a/test-engine/client/utils.mjs
+++ b/test-engine/client/utils.mjs
@@ -72,8 +72,15 @@ export function logRequest (url, init, reqNum) {
   console.log('')
 }
 
-export function logResponse (response, reqNum) {
+export function logResponse (response, interimResponses, reqNum) {
   console.log(`${defines.GREEN}=== Client response ${reqNum}${defines.NC}`)
+  for (const [statusCode, headers] of interimResponses) {
+    console.log(`    HTTP ${statusCode}`)
+    for (const [key, value] of Object.entries(headers)) {
+      console.log(`    ${key}: ${value}`)
+    }
+    console.log('')
+  }
   console.log(`    HTTP ${response.status} ${response.statusText}`)
   response.headers.forEach((hvalue, hname) => { // for some reason, node-fetch reverses these
     console.log(`    ${hname}: ${hvalue}`)

--- a/test-engine/lib/testsuite-schema.json
+++ b/test-engine/lib/testsuite-schema.json
@@ -133,6 +133,102 @@
                     "description": "Whether to rewrite Location and Content-Location to full URLs",
                     "type": "boolean"
                   },
+                  "interim_responses": {
+                    "description": "Interim responses to send before the final response",
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "description": "Status code only",
+                          "type": "array",
+                          "minItems": 1,
+                          "maxItems": 1,
+                          "items": [
+                            {
+                              "$ref": "#/definitions/status-code"
+                            }
+                          ]
+                        },
+                        {
+                          "description": "Status code and headers",
+                          "type": "array",
+                          "minItems": 2,
+                          "maxItems": 2,
+                          "items": [
+                            {
+                              "$ref": "#/definitions/status-code"
+                            },
+                            {
+                              "description": "Interim response headers",
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "additionalItems": false,
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                  {
+                                    "$ref": "#/definitions/field-name"
+                                  },
+                                  {
+                                    "$ref": "#/definitions/magic-field-value"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "expected_interim_responses": {
+                    "description": "Interim responses expected to be received by the client",
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "description": "Status code only",
+                          "type": "array",
+                          "minItems": 1,
+                          "maxItems": 1,
+                          "items": [
+                            {
+                              "$ref": "#/definitions/status-code"
+                            }
+                          ]
+                        },
+                        {
+                          "description": "Status code and headers",
+                          "type": "array",
+                          "minItems": 2,
+                          "maxItems": 2,
+                          "items": [
+                            {
+                              "$ref": "#/definitions/status-code"
+                            },
+                            {
+                              "description": "Expected interim response headers",
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "additionalItems": false,
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": [
+                                  {
+                                    "$ref": "#/definitions/field-name"
+                                  },
+                                  {
+                                    "$ref": "#/definitions/magic-field-value"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
                   "magic_ims": {
                     "description": "Whether to rewrite If-Modified-Since to a delta from the previous Last-Modified",
                     "type": "boolean"

--- a/test-engine/lib/tpl/checks.liquid
+++ b/test-engine/lib/tpl/checks.liquid
@@ -7,6 +7,13 @@
 
 ### The following checks will be performed:
 
+{%- if request.interim_responses -%}
+{%- for interim_response in request.interim_responses %}
+- The client will check that an interim response with the `{{ interim_response[0] }}` status code{% if interim_response[1] %} and the following headers{% endif %} is received.
+{%- render 'header-list' with interim_response[1] as headers %}
+{%- endfor -%}
+{%- endif -%}
+
 {%- if request.expected_type %}
 - The client will check that this response {% case request.expected_type %}{% when "cached" %}is cached{% when "not_cached" %}is not cached{% when "lm_validated" %}is validated using `Last-Modified`{% when "etag_validated" %}is validated using `ETag`{% endcase %} {% if test.setup_tests contains "expected_type" %}{{ setup_prop }}{% endif %}{% endif -%}
 

--- a/test-engine/lib/tpl/explain-test.liquid
+++ b/test-engine/lib/tpl/explain-test.liquid
@@ -62,8 +62,16 @@ The server will pause for {{ request.response_pause }} seconds before responding
 
 {%- if request.response_status or request.response_headers or request.response_body %}
 
-### The server sends a response containing:
+### The server sends {% if request.interim_responses %}responses{% else %}a response{% endif %} containing:
+
 ~~~
+{% if request.interim_responses -%}
+{% for interim_response in request.interim_responses -%}
+HTTP/1.1 {{ interim_response[0] }}
+{% for header in interim_response[1] %}{% render 'header-magic' with header as header %}
+{% endfor %}
+{% endfor -%}
+{%- endif -%}
 {% if request.expected_type == "lm_validated" or request.expected_type = "etag_validated" -%}
 HTTP/1.1 304 Not Modified
 {%- else -%}

--- a/test-engine/server/handle-test.mjs
+++ b/test-engine/server/handle-test.mjs
@@ -125,5 +125,5 @@ function continueHandleTest (uuid, request, response, requests, serverState) {
   }
 
   // logging
-  if (reqConfig.dump) logResponse(response, srvReqNum)
+  if (reqConfig.dump) logResponse(response, interimResponses, srvReqNum)
 }

--- a/test-engine/server/handle-test.mjs
+++ b/test-engine/server/handle-test.mjs
@@ -43,6 +43,17 @@ function continueHandleTest (uuid, request, response, requests, serverState) {
   const previousConfig = requests[reqNum - 2]
   const now = Date.now()
 
+  const interimResponses = reqConfig.interim_responses || []
+  for (const [status, headers = []] of interimResponses) {
+    if (status === 102) {
+      response.writeProcessing()
+    } else if (status === 103) {
+      response.writeEarlyHints(Object.fromEntries(headers))
+    } else {
+      console.log(`ERROR: Sending ${status} is not yet supported`)
+    }
+  }
+
   // Determine what the response status should be
   let httpStatus = reqConfig.response_status || [200, 'OK']
   if ('expected_type' in reqConfig && reqConfig.expected_type.endsWith('validated')) {

--- a/test-engine/server/utils.mjs
+++ b/test-engine/server/utils.mjs
@@ -40,11 +40,18 @@ export function logRequest (request, reqNum) {
   console.log('')
 }
 
-export function logResponse (response, resNum) {
+export function logResponse (response, interimResponses, resNum) {
   console.log(`${BLUE}=== Server response ${resNum}${NC}`)
   if (response === 'disconnect') {
     console.log('    [ server disconnect ]')
   } else {
+    for (const [statusCode, headers] of interimResponses) {
+      console.log(`    HTTP ${statusCode}`)
+      for (const [key, value] of headers) {
+        console.log(`    ${key}: ${value}`)
+      }
+      console.log('')
+    }
     console.log(`    HTTP ${response.statusCode} ${response.statusPhrase}`)
     for (const [key, value] of Object.entries(response.getHeaders())) {
       console.log(`    ${key}: ${value}`)

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -22,5 +22,6 @@ import partial from './partial.mjs'
 import auth from './authorization.mjs'
 import other from './other.mjs'
 import cdncc from './cdn-cache-control.mjs'
+import interim from './interim.mjs'
 
-export default [ccFreshness, ccParse, ageParse, expires, expiresParse, ccResponse, stale, heuristic, methods, statuses, ccRequest, pragma, vary, varyParse, conditionalLm, conditionalEtag, headers, update304, updateHead, invalidation, partial, auth, other, cdncc]
+export default [ccFreshness, ccParse, ageParse, expires, expiresParse, ccResponse, stale, heuristic, methods, statuses, ccRequest, pragma, vary, varyParse, conditionalLm, conditionalEtag, headers, update304, updateHead, invalidation, partial, auth, other, cdncc, interim]

--- a/tests/interim.mjs
+++ b/tests/interim.mjs
@@ -1,0 +1,59 @@
+export default
+
+{
+  name: 'Interim Response Handling',
+  id: 'interim',
+  description: 'These tests check how caches handle interim responses.',
+  tests: [
+    {
+      name: 'An optimal HTTP cache passes a 102 response through and caches the final response',
+      id: 'interim-102',
+      browser_skip: true, // Fetch API in browsers don't expose interim responses
+      kind: 'optimal',
+      requests: [
+        {
+          interim_responses: [[102]],
+          expected_interim_responses: [[102]],
+          response_headers: [
+            ['Cache-Control', 'max-age=100000'],
+            ['Date', 0]
+          ],
+          pause_after: true
+        },
+        {
+          expected_type: 'cached'
+        }
+      ]
+    },
+    {
+      name: 'An optimal HTTP cache passes a 103 response through and caches the final response',
+      id: 'interim-103',
+      browser_skip: true,
+      kind: 'optimal',
+      requests: [
+        {
+          interim_responses: [
+            [103, [
+              ['link', '</styles.css>; rel=preload; as=style'],
+              ['x-my-header', 'test']
+            ]]
+          ],
+          expected_interim_responses: [
+            [103, [
+              ['link', '</styles.css>; rel=preload; as=style'],
+              ['x-my-header', 'test']
+            ]]
+          ],
+          response_headers: [
+            ['Cache-Control', 'max-age=100000'],
+            ['Date', 0]
+          ],
+          pause_after: true
+        },
+        {
+          expected_type: 'cached'
+        }
+      ]
+    }
+  ]
+}

--- a/tests/interim.mjs
+++ b/tests/interim.mjs
@@ -54,6 +54,71 @@ export default
           expected_type: 'cached'
         }
       ]
+    },
+    {
+      name: 'An HTTP cache should not cache non-final responses',
+      id: 'interim-not-cached',
+      browser_skip: true,
+      kind: 'required',
+      requests: [
+        {
+          interim_responses: [
+            [103, [
+              ['link', '</styles.css>; rel=preload; as=style']
+            ]]
+          ],
+          expected_interim_responses: [
+            [103, [
+              ['link', '</styles.css>; rel=preload; as=style']
+            ]]
+          ],
+          response_headers: [
+            ['Cache-Control', 'max-age=100000'],
+            ['Date', 0]
+          ],
+          pause_after: true
+        },
+        {
+          expected_type: 'cached',
+          expected_interim_responses: []
+        }
+      ]
+    },
+    {
+      name: 'An optimal HTTP cache should not store headers from non-final responses',
+      id: 'interim-no-header-reuse',
+      browser_skip: true,
+      kind: 'optimal',
+      requests: [
+        {
+          interim_responses: [
+            [103, [
+              ['link', '</styles.css>; rel=preload; as=style'],
+              ['x-my-header', 'test']
+            ]]
+          ],
+          expected_interim_responses: [
+            [103, [
+              ['link', '</styles.css>; rel=preload; as=style'],
+              ['x-my-header', 'test']
+            ]]
+          ],
+          response_headers: [
+            ['Cache-Control', 'max-age=100000'],
+            ['Date', 0]
+          ],
+          expected_response_headers_missing: [
+            'x-my-header'
+          ],
+          pause_after: true
+        },
+        {
+          expected_type: 'cached',
+          expected_response_headers_missing: [
+            'x-my-header'
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
During one of the HTTP WG session at the IETF 121 meeting in Dublin, resumable uploads was discussed and the topic of support for interim responses in the current HTTP ecosystem came up. @mnot suggested that the cache-tests could be used to test how proxies handle interim responses.

This PR takes a first stab at this. It implements two tests for the 102 and 103 status codes. I would have liked to test an informational status code that is not yet registered to ensure that proxies don't limit their behavior to specific status codes, but currently Node.js' http module does not support sending arbitrary interim responses (see https://github.com/nodejs/node/issues/27921#issuecomment-2223488316). The tests check that proxies pass interim responses through, but are still able to cache the final response.

So far, support for this is varying:
- Apache and Squid meet the expected behavior
- Nginx passes the interim responses through, but doesn't cache the final response
- Caddy ignores the interim responses entirely
- Varnish responds with a 503 upon receiving an interim response
- Trafficserver ignores the 103 but fails to respond for the 102

I can imagine that some of these failures are due to missing configuration settings. For example, for Nginx it was necessary to enable HTTP/1.1 to the origin. Otherwise it fell back to HTTP/1.0 which does not support interim responses as far as I know.

To accommodate the new tests, the `interim_response` and `expected_interim_responses` configurations have been added. Since the Fetch API itself does not expose interim responses to the caller, they have to be collected using the ability to intercept dispatcher in Node.js' `undici` module, which is the implementation behind Node's Fetch API. See https://undici.nodejs.org/#/docs/api/Dispatcher?id=dispatchercomposeinterceptors-interceptor for more details.

I would be happy for any feedback regarding the tests themselves, as well as the code changes.