### PR TITLE
Add HAProxy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     apache2 \
     varnish \
     golang \
+    haproxy \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -68,6 +69,13 @@ RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 RUN ~/go/bin/xcaddy build --with github.com/caddyserver/cache-handler
 COPY caddy/Caddyfile /etc/caddy/Caddyfile
 EXPOSE 8006
+
+
+# haproxy
+
+COPY haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
+EXPOSE 8007
+
 
 # setup
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,6 +23,9 @@ if [[ ! -z $1 ]] ; then
     # caddy
     sed -i s/127.0.0.1/$1/ /etc/caddy/Caddyfile
 
+    # haproxy
+    sed -i s/127.0.0.1/$1/ /etc/haproxy/haproxy.cfg
+
     serve.sh
   fi
 

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -1,0 +1,13 @@
+defaults
+  mode http
+  timeout connect 5s
+  timeout client 1m
+  timeout server 1m
+
+frontend fe
+  bind :8007
+  default_backend be
+
+backend be
+  server s1 127.0.0.1:8000
+

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -4,8 +4,18 @@ defaults
   timeout client 1m
   timeout server 1m
 
+cache mycache
+  total-max-size 4
+  max-object-size 10000
+  max-age 240
+  process-vary on
+  max-secondary-entries 12
+
 frontend fe
   bind :8007
+  filter cache mycache
+  http-request cache-use mycache
+  http-response cache-store mycache
   default_backend be
 
 backend be

--- a/docker/serve.sh
+++ b/docker/serve.sh
@@ -17,4 +17,7 @@ echo "* Starting Varnish"
 /usr/sbin/varnishd -j unix -a 0.0.0.0:8005 -f /etc/varnish/default.vcl -p default_ttl=0 -p default_grace=0 -p default_keep=3600 -s malloc,64M
 
 echo "* Starting Caddy"
-HOME=/root /caddy run --config /etc/caddy/Caddyfile
+HOME=/root /caddy run --config /etc/caddy/Caddyfile &
+
+echo "* Starting HAProxy"
+/usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg &

--- a/results/haproxy.json
+++ b/results/haproxy.json
@@ -91,10 +91,7 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "age-parse-dup-old": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "age-parse-dup-old": true,
   "age-parse-float": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -122,13 +119,10 @@
   ],
   "age-parse-suffix": true,
   "age-parse-suffix-twoline": true,
-  "cc-resp-must-revalidate-fresh": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "cc-resp-must-revalidate-fresh": true,
   "cc-resp-must-revalidate-stale": [
-    "Setup",
-    "Response 2 does not come from cache"
+    "Assertion",
+    "Request 3 should have been conditional, but it was not."
   ],
   "cc-resp-no-cache": true,
   "cc-resp-no-cache-case-insensitive": true,
@@ -143,18 +137,15 @@
   "cc-resp-no-store": true,
   "cc-resp-no-store-case-insensitive": true,
   "cc-resp-no-store-fresh": true,
-  "cc-resp-no-store-old-max-age": [
-    "Assertion",
-    "Response 3 does not come from cache"
-  ],
-  "cc-resp-no-store-old-new": [
-    "Assertion",
-    "Response 3 does not come from cache"
-  ],
+  "cc-resp-no-store-old-max-age": true,
+  "cc-resp-no-store-old-new": true,
   "cc-resp-private-shared": true,
   "ccreq-ma0": true,
   "ccreq-ma1": true,
-  "ccreq-magreaterage": true,
+  "ccreq-magreaterage": [
+    "Setup",
+    "Response 1 header Age is \"null\", not \"1800\""
+  ],
   "ccreq-max-stale": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -164,7 +155,10 @@
     "Response 2 does not come from cache"
   ],
   "ccreq-min-fresh": true,
-  "ccreq-min-fresh-age": true,
+  "ccreq-min-fresh-age": [
+    "Setup",
+    "Response 1 header Age is \"null\", not \"1000\""
+  ],
   "ccreq-no-cache": true,
   "ccreq-no-cache-etag": [
     "Assertion",
@@ -174,17 +168,23 @@
     "Assertion",
     "Request 2 should have been conditional, but it was not."
   ],
-  "ccreq-no-store": true,
+  "ccreq-no-store": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
   "ccreq-oic": [
     "Assertion",
     "Response 1 status is 200, not 504"
   ],
   "cdn-cc-invalid-sh-type-unknown": true,
-  "cdn-cc-invalid-sh-type-wrong": true,
+  "cdn-cc-invalid-sh-type-wrong": [
+    "AbortError",
+    "This operation was aborted"
+  ],
   "cdn-date-update-exceed": true,
   "cdn-expires-update-exceed": [
     "Assertion",
-    "Response 2 header Expires is \"null\", not \"Wed, 12 Mar 2025 10:09:07 GMT\""
+    "Response 2 header Expires is \"null\", not \"Wed, 12 Mar 2025 10:13:52 GMT\""
   ],
   "cdn-fresh-cc-nostore": [
     "Assertion",
@@ -195,7 +195,10 @@
     "Response 2 does not come from cache"
   ],
   "cdn-max-age-0": true,
-  "cdn-max-age-0-expires": true,
+  "cdn-max-age-0-expires": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
   "cdn-max-age-age": true,
   "cdn-max-age-case-insensitive": [
     "Assertion",
@@ -213,7 +216,10 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "cdn-max-age-long-cc-max-age": true,
+  "cdn-max-age-long-cc-max-age": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
   "cdn-max-age-max": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -228,30 +234,33 @@
   ],
   "cdn-max-age-space-after-equals": true,
   "cdn-max-age-space-before-equals": true,
-  "cdn-no-cache": true,
-  "cdn-no-store-cc-fresh": true,
-  "cdn-private": true,
+  "cdn-no-cache": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
+  "cdn-no-store-cc-fresh": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
+  "cdn-private": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
   "cdn-remove-age-exceed": [
     "Assertion",
     "Response 2 Age header not present."
   ],
   "cdn-remove-header": true,
-  "conditional-304-etag": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "conditional-304-etag": true,
   "conditional-etag-forward": true,
   "conditional-etag-forward-unquoted": [
     "Assertion",
     "Request 1 header If-None-Match is \"abcdef\", not \"\"abcdef\"\""
   ],
-  "conditional-etag-precedence": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "conditional-etag-precedence": true,
   "conditional-etag-quoted-respond-unquoted": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
   "conditional-etag-strong-generate": [
     "Assertion",
@@ -261,33 +270,21 @@
     "Assertion",
     "Request 2 should have been conditional, but it was not."
   ],
-  "conditional-etag-strong-respond": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "conditional-etag-strong-respond-multiple-first": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "conditional-etag-strong-respond-multiple-last": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "conditional-etag-strong-respond-multiple-second": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "conditional-etag-strong-respond": true,
+  "conditional-etag-strong-respond-multiple-first": true,
+  "conditional-etag-strong-respond-multiple-last": true,
+  "conditional-etag-strong-respond-multiple-second": true,
   "conditional-etag-strong-respond-obs-text": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
   "conditional-etag-unquoted-respond-quoted": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
   "conditional-etag-unquoted-respond-unquoted": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
   "conditional-etag-vary-headers": [
     "Setup",
@@ -298,78 +295,54 @@
     "Assertion",
     "Request 2 should have been conditional, but it was not."
   ],
-  "conditional-etag-weak-respond": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "conditional-etag-weak-respond": true,
   "conditional-etag-weak-respond-backslash": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
   "conditional-etag-weak-respond-lowercase": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
   "conditional-etag-weak-respond-omit-slash": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 304"
   ],
-  "conditional-lm-fresh": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "conditional-lm-fresh-earlier": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "conditional-lm-fresh": true,
+  "conditional-lm-fresh-earlier": true,
   "conditional-lm-fresh-no-lm": [
-    "Setup",
-    "Response 2 does not come from cache"
+    "Assertion",
+    "Response 2 status is 200, not 304"
   ],
-  "conditional-lm-fresh-rfc850": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
+  "conditional-lm-fresh-rfc850": true,
   "conditional-lm-stale": true,
-  "freshness-expires-32bit": [
+  "freshness-expires-32bit": true,
+  "freshness-expires-age-fast-date": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 comes from cache"
   ],
-  "freshness-expires-age-fast-date": true,
   "freshness-expires-age-slow-date": true,
-  "freshness-expires-ansi-c": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-expires-far-future": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-expires-future": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-expires-ansi-c": true,
+  "freshness-expires-far-future": true,
+  "freshness-expires-future": true,
   "freshness-expires-invalid": true,
   "freshness-expires-invalid-1-digit-hour": true,
   "freshness-expires-invalid-2-digit-year": true,
   "freshness-expires-invalid-aest": true,
-  "freshness-expires-invalid-date": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-expires-invalid-date": true,
   "freshness-expires-invalid-date-dashes": true,
   "freshness-expires-invalid-multiple-lines": true,
   "freshness-expires-invalid-multiple-spaces": true,
   "freshness-expires-invalid-no-comma": true,
   "freshness-expires-invalid-time-periods": true,
   "freshness-expires-invalid-utc": true,
-  "freshness-expires-old-date": true,
+  "freshness-expires-old-date": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
   "freshness-expires-past": true,
   "freshness-expires-present": true,
-  "freshness-expires-rfc850": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-expires-rfc850": true,
   "freshness-expires-wrong-case-month": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -382,87 +355,48 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "freshness-max-age": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age": true,
   "freshness-max-age-0": true,
   "freshness-max-age-0-expires": true,
-  "freshness-max-age-100a": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age-100a": true,
   "freshness-max-age-a100": [
     "Assertion",
     "Response 2 does not come from cache"
   ],
   "freshness-max-age-age": true,
-  "freshness-max-age-case-insenstive": [
+  "freshness-max-age-case-insenstive": true,
+  "freshness-max-age-date": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 comes from cache"
   ],
-  "freshness-max-age-date": true,
-  "freshness-max-age-decimal-five": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-decimal-zero": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-expires": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-expires-invalid": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-extension": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age-decimal-five": true,
+  "freshness-max-age-decimal-zero": true,
+  "freshness-max-age-expires": true,
+  "freshness-max-age-expires-invalid": true,
+  "freshness-max-age-extension": true,
   "freshness-max-age-ignore-quoted": true,
   "freshness-max-age-ignore-quoted-rev": true,
-  "freshness-max-age-leading-zero": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-max": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-max-minus-1": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-max-plus": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-max-plus-1": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age-leading-zero": true,
+  "freshness-max-age-max": true,
+  "freshness-max-age-max-minus-1": true,
+  "freshness-max-age-max-plus": true,
+  "freshness-max-age-max-plus-1": true,
   "freshness-max-age-negative": true,
-  "freshness-max-age-quoted": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age-quoted": true,
   "freshness-max-age-s-maxage-shared-longer": true,
   "freshness-max-age-s-maxage-shared-longer-multiple": true,
   "freshness-max-age-s-maxage-shared-longer-reversed": true,
-  "freshness-max-age-s-maxage-shared-shorter": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-s-maxage-shared-shorter-expires": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age-s-maxage-shared-shorter": true,
+  "freshness-max-age-s-maxage-shared-shorter-expires": true,
   "freshness-max-age-single-quoted": true,
-  "freshness-max-age-space-after-equals": true,
-  "freshness-max-age-space-before-equals": true,
+  "freshness-max-age-space-after-equals": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
+  "freshness-max-age-space-before-equals": [
+    "Assertion",
+    "Response 2 comes from cache"
+  ],
   "freshness-max-age-stale": true,
   "freshness-max-age-two-fresh-stale-sameline": [
     "Assertion",
@@ -472,19 +406,10 @@
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "freshness-max-age-two-stale-fresh-sameline": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "freshness-max-age-two-stale-fresh-sepline": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-max-age-two-stale-fresh-sameline": true,
+  "freshness-max-age-two-stale-fresh-sepline": true,
   "freshness-none": true,
-  "freshness-s-maxage-shared": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "freshness-s-maxage-shared": true,
   "head-200-freshness-update": [
     "Assertion",
     "Response 3 does not come from cache"
@@ -503,137 +428,50 @@
   ],
   "head-writethrough": true,
   "headers-omit-headers-listed-in-Cache-Control-no-cache": [
-    "Setup",
-    "Response 2 does not come from cache"
+    "Assertion",
+    "Response 2 includes unexpected header a: \"1\""
   ],
   "headers-omit-headers-listed-in-Cache-Control-no-cache-single": [
-    "Setup",
-    "Response 2 does not come from cache"
+    "Assertion",
+    "Response 2 includes unexpected header a: \"1\""
   ],
   "headers-omit-headers-listed-in-Connection": [
-    "Setup",
-    "Response 2 does not come from cache"
+    "Assertion",
+    "Response 2 includes unexpected header a: \"1\""
   ],
-  "headers-store-Cache-Control": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Clear-Site-Data": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Connection": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Encoding": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Foo": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Length": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Location": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-MD5": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Range": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Security-Policy": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Content-Type": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-ETag": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Expires": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Keep-Alive": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Proxy-Authenticate": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Proxy-Authentication-Info": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Proxy-Authorization": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Proxy-Connection": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Public-Key-Pins": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Set-Cookie": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Set-Cookie2": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-TE": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-Test-Header": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
+  "headers-store-Cache-Control": true,
+  "headers-store-Clear-Site-Data": true,
+  "headers-store-Connection": true,
+  "headers-store-Content-Encoding": true,
+  "headers-store-Content-Foo": true,
+  "headers-store-Content-Length": true,
+  "headers-store-Content-Location": true,
+  "headers-store-Content-MD5": true,
+  "headers-store-Content-Range": true,
+  "headers-store-Content-Security-Policy": true,
+  "headers-store-Content-Type": true,
+  "headers-store-ETag": true,
+  "headers-store-Expires": true,
+  "headers-store-Keep-Alive": true,
+  "headers-store-Proxy-Authenticate": true,
+  "headers-store-Proxy-Authentication-Info": true,
+  "headers-store-Proxy-Authorization": true,
+  "headers-store-Proxy-Connection": true,
+  "headers-store-Public-Key-Pins": true,
+  "headers-store-Set-Cookie": true,
+  "headers-store-Set-Cookie2": true,
+  "headers-store-TE": true,
+  "headers-store-Test-Header": true,
   "headers-store-Transfer-Encoding": [
     "Setup",
     "Response 1 status is 502, not 200"
   ],
-  "headers-store-Upgrade": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-X-Content-Foo": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-X-Frame-Options": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-X-Test-Header": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "headers-store-X-XSS-Protection": [
-    "Setup",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-200-cached": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "headers-store-Upgrade": true,
+  "headers-store-X-Content-Foo": true,
+  "headers-store-X-Frame-Options": true,
+  "headers-store-X-Test-Header": true,
+  "headers-store-X-XSS-Protection": true,
+  "heuristic-200-cached": true,
   "heuristic-201-not_cached": true,
   "heuristic-202-not_cached": true,
   "heuristic-203-cached": [
@@ -673,78 +511,57 @@
     "Response 2 does not come from cache"
   ],
   "heuristic-599-not_cached": true,
-  "heuristic-delta-10": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-1200": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-1800": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-30": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-300": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-3600": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-43200": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-5": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-60": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-600": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "heuristic-delta-86400": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "heuristic-delta-10": true,
+  "heuristic-delta-1200": true,
+  "heuristic-delta-1800": true,
+  "heuristic-delta-30": true,
+  "heuristic-delta-300": true,
+  "heuristic-delta-3600": true,
+  "heuristic-delta-43200": true,
+  "heuristic-delta-5": true,
+  "heuristic-delta-60": true,
+  "heuristic-delta-600": true,
+  "heuristic-delta-86400": true,
   "invalidate-DELETE": true,
-  "invalidate-DELETE-cl": true,
-  "invalidate-DELETE-failed": [
+  "invalidate-DELETE-cl": [
     "Assertion",
-    "Response 3 does not come from cache"
+    "Response 3 comes from cache"
   ],
-  "invalidate-DELETE-location": true,
+  "invalidate-DELETE-failed": true,
+  "invalidate-DELETE-location": [
+    "Assertion",
+    "Response 3 comes from cache"
+  ],
   "invalidate-M-SEARCH": true,
-  "invalidate-M-SEARCH-cl": true,
-  "invalidate-M-SEARCH-failed": [
+  "invalidate-M-SEARCH-cl": [
     "Assertion",
-    "Response 3 does not come from cache"
+    "Response 3 comes from cache"
   ],
-  "invalidate-M-SEARCH-location": true,
+  "invalidate-M-SEARCH-failed": true,
+  "invalidate-M-SEARCH-location": [
+    "Assertion",
+    "Response 3 comes from cache"
+  ],
   "invalidate-POST": true,
-  "invalidate-POST-cl": true,
-  "invalidate-POST-failed": [
+  "invalidate-POST-cl": [
     "Assertion",
-    "Response 3 does not come from cache"
+    "Response 3 comes from cache"
   ],
-  "invalidate-POST-location": true,
+  "invalidate-POST-failed": true,
+  "invalidate-POST-location": [
+    "Assertion",
+    "Response 3 comes from cache"
+  ],
   "invalidate-PUT": true,
-  "invalidate-PUT-cl": true,
-  "invalidate-PUT-failed": [
+  "invalidate-PUT-cl": [
     "Assertion",
-    "Response 3 does not come from cache"
+    "Response 3 comes from cache"
   ],
-  "invalidate-PUT-location": true,
+  "invalidate-PUT-failed": true,
+  "invalidate-PUT-location": [
+    "Assertion",
+    "Response 3 comes from cache"
+  ],
   "method-POST": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -753,70 +570,43 @@
     "Assertion",
     "Response 1 age header not present."
   ],
-  "other-age-gen": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "other-age-gen": true,
   "other-age-update-expires": [
-    "Assertion",
-    "Response 2 does not come from cache"
+    "Setup",
+    "Response 1 header Age is \"null\", not \"30\""
   ],
   "other-age-update-max-age": [
-    "Assertion",
-    "Response 2 does not come from cache"
+    "Setup",
+    "Response 1 header Age is \"null\", not \"30\""
   ],
   "other-authorization": true,
   "other-authorization-must-revalidate": [
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "other-authorization-public": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "other-authorization-public": true,
   "other-authorization-smaxage": [
     "Assertion",
     "Response 2 does not come from cache"
   ],
-  "other-cookie": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "other-date-update": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "other-date-update-expires": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "other-date-update-expires-update": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "other-fresh-content-disposition-attachment": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "other-heuristic-content-disposition-attachment": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "other-set-cookie": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "other-cookie": true,
+  "other-date-update": true,
+  "other-date-update-expires": true,
+  "other-date-update-expires-update": true,
+  "other-fresh-content-disposition-attachment": true,
+  "other-heuristic-content-disposition-attachment": true,
+  "other-set-cookie": true,
   "partial-store-complete-reuse-partial": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 206"
   ],
   "partial-store-complete-reuse-partial-no-last": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 206"
   ],
   "partial-store-complete-reuse-partial-suffix": [
     "Assertion",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 206"
   ],
   "partial-store-partial-complete": [
     "Assertion",
@@ -840,24 +630,15 @@
   ],
   "partial-use-headers": [
     "Setup",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 206"
   ],
   "partial-use-stored-headers": [
     "Setup",
-    "Response 2 does not come from cache"
+    "Response 2 status is 200, not 206"
   ],
-  "pragma-request-extension": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "pragma-request-no-cache": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
-  "pragma-response-extension": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "pragma-request-extension": true,
+  "pragma-request-no-cache": true,
+  "pragma-response-extension": true,
   "pragma-response-no-cache": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -867,10 +648,7 @@
     "Response 2 does not come from cache"
   ],
   "query-args-different": true,
-  "query-args-same": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "query-args-same": true,
   "stale-503": [
     "Assertion",
     "Response 2 does not come from cache"
@@ -879,7 +657,10 @@
     "TypeError",
     "fetch failed"
   ],
-  "stale-close-must-revalidate": true,
+  "stale-close-must-revalidate": [
+    "TypeError",
+    "fetch failed"
+  ],
   "stale-close-no-cache": [
     "TypeError",
     "fetch failed"
@@ -888,7 +669,10 @@
     "TypeError",
     "fetch failed"
   ],
-  "stale-close-s-maxage=2": true,
+  "stale-close-s-maxage=2": [
+    "TypeError",
+    "fetch failed"
+  ],
   "stale-sie-503": [
     "TypeError",
     "fetch failed"
@@ -898,8 +682,8 @@
     "fetch failed"
   ],
   "stale-warning-become": [
-    "Setup",
-    "Response 2 does not come from cache"
+    "TypeError",
+    "fetch failed"
   ],
   "stale-warning-stored": [
     "TypeError",
@@ -913,10 +697,7 @@
     "Setup",
     "Response 2 does not come from cache"
   ],
-  "status-200-fresh": [
-    "Assertion",
-    "Response 2 does not come from cache"
-  ],
+  "status-200-fresh": true,
   "status-200-must-understand": [
     "Assertion",
     "Response 2 does not come from cache"

--- a/results/haproxy.json
+++ b/results/haproxy.json
@@ -1,0 +1,1074 @@
+{
+  "304-etag-update-response-Cache-Control": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Clear-Site-Data": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Encoding": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Foo": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Length": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Location": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-MD5": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Range": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Security-Policy": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Content-Type": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-ETag": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Expires": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Public-Key-Pins": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Set-Cookie": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Set-Cookie2": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-Test-Header": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-X-Content-Foo": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-X-Frame-Options": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-X-Test-Header": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-etag-update-response-X-XSS-Protection": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "304-lm-use-stored-Test-Header": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "age-parse-dup-0": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-dup-0-twoline": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-dup-old": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-float": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-large": true,
+  "age-parse-large-minus-one": true,
+  "age-parse-larger": true,
+  "age-parse-negative": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-nonnumeric": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-numeric-parameter": true,
+  "age-parse-parameter": true,
+  "age-parse-prefix": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-prefix-twoline": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "age-parse-suffix": true,
+  "age-parse-suffix-twoline": true,
+  "cc-resp-must-revalidate-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cc-resp-must-revalidate-stale": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "cc-resp-no-cache": true,
+  "cc-resp-no-cache-case-insensitive": true,
+  "cc-resp-no-cache-revalidate": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "cc-resp-no-cache-revalidate-fresh": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "cc-resp-no-store": true,
+  "cc-resp-no-store-case-insensitive": true,
+  "cc-resp-no-store-fresh": true,
+  "cc-resp-no-store-old-max-age": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "cc-resp-no-store-old-new": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "cc-resp-private-shared": true,
+  "ccreq-ma0": true,
+  "ccreq-ma1": true,
+  "ccreq-magreaterage": true,
+  "ccreq-max-stale": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "ccreq-max-stale-age": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "ccreq-min-fresh": true,
+  "ccreq-min-fresh-age": true,
+  "ccreq-no-cache": true,
+  "ccreq-no-cache-etag": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "ccreq-no-cache-lm": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "ccreq-no-store": true,
+  "ccreq-oic": [
+    "Assertion",
+    "Response 1 status is 200, not 504"
+  ],
+  "cdn-cc-invalid-sh-type-unknown": true,
+  "cdn-cc-invalid-sh-type-wrong": true,
+  "cdn-date-update-exceed": true,
+  "cdn-expires-update-exceed": [
+    "Assertion",
+    "Response 2 header Expires is \"null\", not \"Wed, 12 Mar 2025 10:09:07 GMT\""
+  ],
+  "cdn-fresh-cc-nostore": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-0": true,
+  "cdn-max-age-0-expires": true,
+  "cdn-max-age-age": true,
+  "cdn-max-age-case-insensitive": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-cc-max-age-invalid-expires": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-expires": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-extension": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-long-cc-max-age": true,
+  "cdn-max-age-max": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-max-plus": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-short-cc-max-age": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "cdn-max-age-space-after-equals": true,
+  "cdn-max-age-space-before-equals": true,
+  "cdn-no-cache": true,
+  "cdn-no-store-cc-fresh": true,
+  "cdn-private": true,
+  "cdn-remove-age-exceed": [
+    "Assertion",
+    "Response 2 Age header not present."
+  ],
+  "cdn-remove-header": true,
+  "conditional-304-etag": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-forward": true,
+  "conditional-etag-forward-unquoted": [
+    "Assertion",
+    "Request 1 header If-None-Match is \"abcdef\", not \"\"abcdef\"\""
+  ],
+  "conditional-etag-precedence": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-quoted-respond-unquoted": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-strong-generate": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "conditional-etag-strong-generate-unquoted": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "conditional-etag-strong-respond": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-strong-respond-multiple-first": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-strong-respond-multiple-last": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-strong-respond-multiple-second": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-strong-respond-obs-text": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-unquoted-respond-quoted": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-unquoted-respond-unquoted": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-vary-headers": [
+    "Setup",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "conditional-etag-vary-headers-mismatch": true,
+  "conditional-etag-weak-generate-weak": [
+    "Assertion",
+    "Request 2 should have been conditional, but it was not."
+  ],
+  "conditional-etag-weak-respond": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-weak-respond-backslash": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-weak-respond-lowercase": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-etag-weak-respond-omit-slash": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-lm-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-lm-fresh-earlier": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-lm-fresh-no-lm": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-lm-fresh-rfc850": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "conditional-lm-stale": true,
+  "freshness-expires-32bit": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-age-fast-date": true,
+  "freshness-expires-age-slow-date": true,
+  "freshness-expires-ansi-c": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-far-future": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-future": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-invalid": true,
+  "freshness-expires-invalid-1-digit-hour": true,
+  "freshness-expires-invalid-2-digit-year": true,
+  "freshness-expires-invalid-aest": true,
+  "freshness-expires-invalid-date": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-invalid-date-dashes": true,
+  "freshness-expires-invalid-multiple-lines": true,
+  "freshness-expires-invalid-multiple-spaces": true,
+  "freshness-expires-invalid-no-comma": true,
+  "freshness-expires-invalid-time-periods": true,
+  "freshness-expires-invalid-utc": true,
+  "freshness-expires-old-date": true,
+  "freshness-expires-past": true,
+  "freshness-expires-present": true,
+  "freshness-expires-rfc850": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-wrong-case-month": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-wrong-case-tz": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-expires-wrong-case-weekday": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-0": true,
+  "freshness-max-age-0-expires": true,
+  "freshness-max-age-100a": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-a100": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-age": true,
+  "freshness-max-age-case-insenstive": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-date": true,
+  "freshness-max-age-decimal-five": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-decimal-zero": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-expires": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-expires-invalid": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-extension": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-ignore-quoted": true,
+  "freshness-max-age-ignore-quoted-rev": true,
+  "freshness-max-age-leading-zero": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-max": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-max-minus-1": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-max-plus": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-max-plus-1": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-negative": true,
+  "freshness-max-age-quoted": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-s-maxage-shared-longer": true,
+  "freshness-max-age-s-maxage-shared-longer-multiple": true,
+  "freshness-max-age-s-maxage-shared-longer-reversed": true,
+  "freshness-max-age-s-maxage-shared-shorter": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-s-maxage-shared-shorter-expires": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-single-quoted": true,
+  "freshness-max-age-space-after-equals": true,
+  "freshness-max-age-space-before-equals": true,
+  "freshness-max-age-stale": true,
+  "freshness-max-age-two-fresh-stale-sameline": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-two-fresh-stale-sepline": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-two-stale-fresh-sameline": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-max-age-two-stale-fresh-sepline": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "freshness-none": true,
+  "freshness-s-maxage-shared": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "head-200-freshness-update": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "head-200-retain": [
+    "Assertion",
+    "Response 2 header Template-A is \"null\", not \"1\""
+  ],
+  "head-200-update": [
+    "Setup",
+    "Response 3 does not come from cache"
+  ],
+  "head-410-update": [
+    "Setup",
+    "Response 3 does not come from cache"
+  ],
+  "head-writethrough": true,
+  "headers-omit-headers-listed-in-Cache-Control-no-cache": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-omit-headers-listed-in-Cache-Control-no-cache-single": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-omit-headers-listed-in-Connection": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Cache-Control": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Clear-Site-Data": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Connection": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Encoding": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Foo": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Length": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Location": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-MD5": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Range": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Security-Policy": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Content-Type": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-ETag": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Expires": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Keep-Alive": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Proxy-Authenticate": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Proxy-Authentication-Info": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Proxy-Authorization": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Proxy-Connection": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Public-Key-Pins": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Set-Cookie": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Set-Cookie2": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-TE": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Test-Header": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-Transfer-Encoding": [
+    "Setup",
+    "Response 1 status is 502, not 200"
+  ],
+  "headers-store-Upgrade": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-X-Content-Foo": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-X-Frame-Options": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-X-Test-Header": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "headers-store-X-XSS-Protection": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-200-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-201-not_cached": true,
+  "heuristic-202-not_cached": true,
+  "heuristic-203-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-204-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-403-not_cached": true,
+  "heuristic-404-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-405-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-410-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-414-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-501-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-502-not_cached": true,
+  "heuristic-503-not_cached": true,
+  "heuristic-504-not_cached": true,
+  "heuristic-599-cached": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-599-not_cached": true,
+  "heuristic-delta-10": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-1200": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-1800": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-30": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-300": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-3600": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-43200": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-5": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-60": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-600": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "heuristic-delta-86400": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "invalidate-DELETE": true,
+  "invalidate-DELETE-cl": true,
+  "invalidate-DELETE-failed": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "invalidate-DELETE-location": true,
+  "invalidate-M-SEARCH": true,
+  "invalidate-M-SEARCH-cl": true,
+  "invalidate-M-SEARCH-failed": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "invalidate-M-SEARCH-location": true,
+  "invalidate-POST": true,
+  "invalidate-POST-cl": true,
+  "invalidate-POST-failed": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "invalidate-POST-location": true,
+  "invalidate-PUT": true,
+  "invalidate-PUT-cl": true,
+  "invalidate-PUT-failed": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "invalidate-PUT-location": true,
+  "method-POST": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-age-delay": [
+    "Assertion",
+    "Response 1 age header not present."
+  ],
+  "other-age-gen": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-age-update-expires": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-age-update-max-age": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-authorization": true,
+  "other-authorization-must-revalidate": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-authorization-public": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-authorization-smaxage": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-cookie": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-date-update": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-date-update-expires": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-date-update-expires-update": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-fresh-content-disposition-attachment": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-heuristic-content-disposition-attachment": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "other-set-cookie": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-complete-reuse-partial": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-complete-reuse-partial-no-last": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-complete-reuse-partial-suffix": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-partial-complete": [
+    "Assertion",
+    "Request 2 header range is \"undefined\", not \"bytes=5-\""
+  ],
+  "partial-store-partial-reuse-partial": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-partial-reuse-partial-absent": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-partial-reuse-partial-byterange": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-store-partial-reuse-partial-suffix": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "partial-use-headers": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "partial-use-stored-headers": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "pragma-request-extension": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "pragma-request-no-cache": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "pragma-response-extension": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "pragma-response-no-cache": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "pragma-response-no-cache-heuristic": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "query-args-different": true,
+  "query-args-same": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "stale-503": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "stale-close": [
+    "TypeError",
+    "fetch failed"
+  ],
+  "stale-close-must-revalidate": true,
+  "stale-close-no-cache": [
+    "TypeError",
+    "fetch failed"
+  ],
+  "stale-close-proxy-revalidate": [
+    "TypeError",
+    "fetch failed"
+  ],
+  "stale-close-s-maxage=2": true,
+  "stale-sie-503": [
+    "TypeError",
+    "fetch failed"
+  ],
+  "stale-sie-close": [
+    "TypeError",
+    "fetch failed"
+  ],
+  "stale-warning-become": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "stale-warning-stored": [
+    "TypeError",
+    "fetch failed"
+  ],
+  "stale-while-revalidate": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "stale-while-revalidate-window": [
+    "Setup",
+    "Response 2 does not come from cache"
+  ],
+  "status-200-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-200-must-understand": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-200-stale": true,
+  "status-203-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-203-stale": true,
+  "status-204-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-204-stale": true,
+  "status-299-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-299-stale": true,
+  "status-301-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-301-stale": true,
+  "status-302-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-302-stale": true,
+  "status-303-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-303-stale": true,
+  "status-307-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-307-stale": true,
+  "status-308-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-308-stale": true,
+  "status-400-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-400-stale": true,
+  "status-404-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-404-stale": true,
+  "status-410-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-410-stale": true,
+  "status-499-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-499-stale": true,
+  "status-500-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-500-stale": true,
+  "status-502-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-502-stale": true,
+  "status-503-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-503-stale": true,
+  "status-504-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-504-stale": true,
+  "status-599-fresh": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "status-599-must-understand": true,
+  "status-599-stale": true,
+  "vary-2-match": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-2-match-omit": true,
+  "vary-2-no-match": true,
+  "vary-3-match": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-3-no-match": true,
+  "vary-3-omit": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-3-order": true,
+  "vary-cache-key": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-invalidate": [
+    "Assertion",
+    "Response 3 does not come from cache"
+  ],
+  "vary-match": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-no-match": true,
+  "vary-normalise-combine": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-normalise-lang-case": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-normalise-lang-order": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-normalise-lang-select": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-normalise-lang-space": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-normalise-space": [
+    "Assertion",
+    "Response 2 does not come from cache"
+  ],
+  "vary-omit": true,
+  "vary-omit-stored": true,
+  "vary-star": true,
+  "vary-syntax-empty-star": true,
+  "vary-syntax-empty-star-lines": true,
+  "vary-syntax-foo-star": true,
+  "vary-syntax-star": true,
+  "vary-syntax-star-foo": true,
+  "vary-syntax-star-star": true,
+  "vary-syntax-star-star-lines": true
+}

--- a/results/index.mjs
+++ b/results/index.mjs
@@ -62,6 +62,13 @@ export default [
     link: 'https://github.com/http-tests/cache-tests/wiki/Caddy'
   },
   {
+    file: 'haproxy.json',
+    name: 'HAProxy',
+    type: 'rev-proxy',
+    version: '3.0.8-1ubuntu1',
+    link: 'https://github.com/http-tests/cache-tests/wiki/HAProxy'
+  },
+  {
     file: 'fastly.json',
     name: 'Fastly',
     type: 'cdn',

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 
 PIDFILE=/tmp/http-cache-test-server.pid
 
-ALL_PROXIES=(squid nginx apache trafficserver varnish caddy)
+ALL_PROXIES=(squid nginx apache trafficserver varnish caddy haproxy)
 DOCKER_PORTS=""
-for PORT in {8001..8006}; do
+for PORT in {8001..8007}; do
   DOCKER_PORTS+="-p 127.0.0.1:${PORT}:${PORT} "
 done
 
@@ -74,6 +74,9 @@ function test_proxy {
       ;;
     caddy)
       PROXY_PORT=8006
+      ;;
+    haproxy)
+      PROXY_PORT=8007
       ;;
     *)
       echo "Proxy ${PKG} not recognised."


### PR DESCRIPTION
This PR adds HAProxy to the list of tested proxies. I followed all steps in https://github.com/http-tests/cache-tests/tree/main/docker#docker-image-for-proxy-caches, but please let me know if additional modifications are necessary. `./test-docker.sh haproxy` works and produces the included results.

The cache configuration for HAProxy has been taken from https://www.haproxy.com/documentation/haproxy-configuration-tutorials/network-performance/caching/ without additional modifications or optimization. So there might be additional settings that could make more tests pass, but I haven't look into those.

For reference, the HAProxy version installed in the Docker image is 3.0.8-1ubuntu1.