### PR TITLE
Fix credentials request option written to init.mode instead of init.credentials

### DIFF
--- a/test-engine/client/fetching.mjs
+++ b/test-engine/client/fetching.mjs
@@ -23,7 +23,7 @@ export function init (idx, reqConfig, prevResp) {
   if ('name' in reqConfig) init.headers.push(['Test-Name', reqConfig.name])
   if ('request_body' in reqConfig) init.body = reqConfig.request_body
   if ('mode' in reqConfig) init.mode = reqConfig.mode
-  if ('credentials' in reqConfig) init.mode = reqConfig.credentials
+  if ('credentials' in reqConfig) init.credentials = reqConfig.credentials
   if ('cache' in reqConfig) init.cache = reqConfig.cache
   if ('redirect' in reqConfig) init.redirect = reqConfig.redirect
   init.headers.push(['Test-ID', reqConfig.id])


### PR DESCRIPTION
Fixes the latent bug in #165: the `credentials` request option was assigned to `init.mode` in `test-engine/client/fetching.mjs`, clobbering `mode` and never reaching `fetch()`. Now assigned to `init.credentials`.

No current test sets `credentials`, but the test-suite schema defines it, so this prevents the first such test from silently misbehaving.

Closes #165

---
🤖 This PR was generated by an AI agent (Claude Code) under human supervision, as part of a maintainer-directed review of the test suite.
