### PR TITLE
Pause only when pause_after is true, not merely present

### DIFF
--- a/test-engine/client/test.mjs
+++ b/test-engine/client/test.mjs
@@ -51,7 +51,7 @@ export async function makeTest (test) {
             clearTimeout(timeout)
           })
       },
-      pauseAfter: 'pause_after' in requests[i]
+      pauseAfter: requests[i].pause_after === true
     })
   }
 


### PR DESCRIPTION
Fixes #166: `pauseAfter` was computed from `'pause_after' in requests[i]`, so `pause_after: false` would still trigger a pause. Now compares the value against `true`.

Latent today (templates only ever set `true`), but removes the no-op trap for anyone overriding a template to `false`.

Closes #166

---
🤖 This PR was generated by an AI agent (Claude Code) under human supervision, as part of a maintainer-directed review of the test suite.
