### PR TITLE
Make stale-sie-503 actually return a 503

### DIFF
--- a/tests/stale.mjs
+++ b/tests/stale.mjs
@@ -142,7 +142,8 @@ export default {
           pause_after: true
         },
         {
-          disconnect: true,
+          response_status: [503, 'Service Unavailable'],
+          expected_status: 200,
           expected_type: 'cached'
         }
       ]


### PR DESCRIPTION
Fixes #167: `stale-sie-503` was a byte-for-byte behavioral duplicate of `stale-sie-close` — its second request used `disconnect: true` rather than returning a 503, so the stale-if-error-on-error-status case was never tested. Its second request now returns `503 Service Unavailable` (mirroring the existing `stale-503` test) and expects a `200` served from the stale cache.

Closes #167

---
🤖 This PR was generated by an AI agent (Claude Code) under human supervision, as part of a maintainer-directed review of the test suite.
