### PR TITLE
Assert no unexpected interim responses were received

### DIFF
--- a/test-engine/client/test.mjs
+++ b/test-engine/client/test.mjs
@@ -223,6 +223,9 @@ function checkResponse (test, requests, idx, response, interimResponses) {
         })
       }
     })
+
+    assert(isSetup, interimResponses.length === reqConfig.expected_interim_responses.length,
+      `Received ${interimResponses.length} interim response(s), expected ${reqConfig.expected_interim_responses.length}`)
   }
 
   return response.text().then(makeCheckResponseBody(test, reqConfig, response.status))


### PR DESCRIPTION
Fixes #168: the interim-response check only verified that *expected* interim responses were present. An empty `expected_interim_responses: []` therefore asserted nothing, so the `kind: required` test `interim-not-cached` could not catch a cache that stored and replayed a `103` interim on a cache hit.

This adds a count assertion that the number of interim responses received equals the number expected. It only fires when `expected_interim_responses` is present, so `interim-102`/`interim-103` (exactly one interim) and `interim-no-header-reuse` (no `expected_interim_responses` on the hit) are unaffected.

Closes #168

---
🤖 This PR was generated by an AI agent (Claude Code) under human supervision, as part of a maintainer-directed review of the test suite.
