### PR TITLE
Make conditional-etag-precedence actually test precedence

### DIFF
--- a/tests/conditional-etag.mjs
+++ b/tests/conditional-etag.mjs
@@ -65,9 +65,14 @@ export default {
           ]
         }),
         {
+          // The two conditionals are intentionally in disagreement: the
+          // matching `If-None-Match` yields 304, whereas `If-Modified-Since`
+          // is set before `Last-Modified` (-10000 vs -5000) so on its own it
+          // would yield 200. Only a cache that gives `If-None-Match`
+          // precedence returns the expected 304.
           request_headers: [
             ['If-None-Match', '"abcdef"'],
-            ['If-Modified-Since', -1]
+            ['If-Modified-Since', -10000]
           ],
           magic_ims: true,
           expected_type: 'cached',


### PR DESCRIPTION
Fixes #169: in `conditional-etag-precedence`, both `If-None-Match` (matches the stored ETag) and `If-Modified-Since` (≈now, after the stored `Last-Modified`) independently evaluated to 304, so any evaluation order passed `expected_status: 304` and a cache that gave `If-Modified-Since` precedence was not caught.

This moves `If-Modified-Since` to before `Last-Modified` (`-10000` vs the response's `-5000`), so it alone would yield 200 while `If-None-Match` still yields 304. Only a cache that correctly gives `If-None-Match` precedence (RFC 9110 §13.2.2) returns the expected 304.

Closes #169

---
🤖 This PR was generated by an AI agent (Claude Code) under human supervision, as part of a maintainer-directed review of the test suite.
