### PR TITLE
Make vary-3-order isolate header order

### DIFF
--- a/tests/vary.mjs
+++ b/tests/vary.mjs
@@ -245,19 +245,20 @@ export default {
       ]
     },
     {
-      name: "HTTP cache must not reuse three-way `Vary` response when request doesn't match, regardless of header order",
+      name: 'An optimal HTTP cache reuses a three-way `Vary` response regardless of request header order',
       id: 'vary-3-order',
       spec_anchors: ['caching.negotiated.responses'],
       depends_on: ['vary-3-match'],
+      kind: 'optimal',
       requests: [
         vary3Setup({}),
         {
           request_headers: [
             ['Foo', '1'],
             ['Baz', '789'],
-            ['Bar', 'abcde']
+            ['Bar', 'abc']
           ],
-          expected_type: 'not_cached'
+          expected_type: 'cached'
         }
       ]
     },


### PR DESCRIPTION
Fixes #170: `vary-3-order` claimed to test matching "regardless of header order" but reordered the headers *and* changed `Bar`'s value (`abcde` vs stored `abc`). The value mismatch alone forced `not_cached`, so ordering was never exercised — it was effectively a duplicate of `vary-3-no-match`.

This converts it into a real order-independence test: the request sends the stored values (`Foo:1, Bar:abc, Baz:789`) in a different order and expects reuse (`cached`). A cache that did order-sensitive secondary-key comparison would fail to match.

**Design note / alternative:** I chose to make this a positive order-independence test (expected `cached`, `kind: optimal`, renamed). The alternative would be to keep it a no-match test and simply drop the "regardless of header order" framing from the name — but that would leave it redundant with `vary-3-no-match`. Happy to switch to the conservative wording-only fix if preferred.

Closes #170

---
🤖 This PR was generated by an AI agent (Claude Code) under human supervision, as part of a maintainer-directed review of the test suite.
